### PR TITLE
[codex] fix(rakuma): normalize missing patrol items as deleted

### DIFF
--- a/services/patrol/rakuma_patrol.py
+++ b/services/patrol/rakuma_patrol.py
@@ -33,15 +33,23 @@ class RakumaPatrol(BasePatrol):
             body_text = extract_rakuma_page_text(page)
 
             if http_status == 404:
-                return self._finalize_result("rakuma", url, PatrolResult(error="Rakuma item unavailable (404)"))
+                return self._finalize_result(
+                    "rakuma",
+                    url,
+                    PatrolResult(status="deleted", confidence="high", reason="http-404"),
+                )
 
             if is_rakuma_missing_item_page(body_text):
-                return self._finalize_result("rakuma", url, PatrolResult(error="Rakuma item unavailable"))
+                return self._finalize_result(
+                    "rakuma",
+                    url,
+                    PatrolResult(status="deleted", confidence="high", reason="missing-item-marker"),
+                )
 
             parsed = parse_rakuma_item_page(page, url, body_text=body_text)
             status = self._normalize_status(parsed.get("status"))
 
-            if not parsed.get("title") and parsed.get("price") is None and status != "sold":
+            if not parsed.get("title") and parsed.get("price") is None and status not in {"sold", "deleted"}:
                 return self._finalize_result("rakuma", url, PatrolResult(error="Rakuma page missing expected item data"))
 
             return self._finalize_result("rakuma", url, PatrolResult(price=parsed.get("price"), status=status, variants=[]))
@@ -64,8 +72,8 @@ class RakumaPatrol(BasePatrol):
 
     @staticmethod
     def _normalize_status(status: str | None) -> str:
-        if status == "sold":
-            return "sold"
+        if status in {"sold", "deleted"}:
+            return status
         if status in {"on_sale", "active"}:
             return "active"
         return "unknown"

--- a/tests/test_monitor_service.py
+++ b/tests/test_monitor_service.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 from models import Product, User, Variant
 from services.monitor_service import MonitorService
@@ -236,6 +237,70 @@ def test_patrol_deleted_status_only_preserves_price_and_zeroes_inventory(client,
     assert refreshed.last_price == 4200
     assert refreshed.last_status == 'deleted'
     assert refreshed_variant.inventory_qty == 0
+
+
+def test_rakuma_404_marks_product_deleted_without_backoff(client, db_session, monkeypatch):
+    user = _create_user(db_session, 'monitor_rakuma_deleted_user')
+    old_time = utc_now() - timedelta(days=1)
+
+    product = Product(
+        user_id=user.id,
+        site='rakuma',
+        source_url='https://item.fril.jp/4c9cbe23f444f98740ea830f5f6a8eee',
+        last_title='Rakuma Item',
+        last_price=4200,
+        last_status='on_sale',
+        archived=False,
+        deleted_at=None,
+        patrol_fail_count=2,
+        created_at=old_time,
+        updated_at=old_time,
+    )
+    db_session.add(product)
+    db_session.commit()
+
+    variant = Variant(
+        product_id=product.id,
+        option1_value='Default Title',
+        sku='RAK-MON-404',
+        price=4200,
+        inventory_qty=1,
+        position=1,
+    )
+    db_session.add(variant)
+    db_session.commit()
+
+    events = []
+
+    class FakeDispatcher:
+        def notify_scrape_issue(self, **payload):
+            events.append(payload)
+            return True
+
+    monkeypatch.setattr("services.scrape_alerts.get_alert_dispatcher", lambda: FakeDispatcher())
+
+    mock_page = MagicMock()
+    mock_page.status = 404
+    mock_page.get_text.return_value = "ページが見つかりません"
+    mock_page.css.return_value = []
+
+    import services.patrol.rakuma_patrol as rakuma_patrol
+
+    monkeypatch.setattr(rakuma_patrol, "fetch_static", lambda url, follow_redirects=True: mock_page)
+    monkeypatch.setattr(MonitorService, '_patrols', {'rakuma': rakuma_patrol.RakumaPatrol()})
+
+    MonitorService.check_stale_products(limit=10)
+
+    db_session.expire_all()
+    refreshed = db_session.query(Product).filter_by(id=product.id).one()
+    refreshed_variant = db_session.query(Variant).filter_by(product_id=product.id).one()
+
+    assert refreshed.patrol_fail_count == 0
+    assert refreshed.last_price == 4200
+    assert refreshed.last_status == 'deleted'
+    assert refreshed_variant.inventory_qty == 0
+    assert refreshed.updated_at <= utc_now() + timedelta(seconds=10)
+    assert events == []
 
 
 def test_low_confidence_active_without_price_triggers_backoff(client, db_session, monkeypatch):

--- a/tests/test_rakuma_playwright.py
+++ b/tests/test_rakuma_playwright.py
@@ -553,8 +553,17 @@ def test_rakuma_patrol_maps_on_sale_to_active(_patch_scrapling):
     assert result.status == "active"
 
 
-def test_rakuma_patrol_returns_error_on_404(_patch_scrapling):
-    """RakumaPatrol が HTTP 404 を unavailable エラーとして扱うことを確認"""
+def test_rakuma_patrol_returns_deleted_on_404_without_alert(_patch_scrapling, monkeypatch):
+    """RakumaPatrol は HTTP 404 を deleted に正規化し、patrol_error を出さない。"""
+    events = []
+
+    class FakeDispatcher:
+        def notify_scrape_issue(self, **payload):
+            events.append(payload)
+            return True
+
+    monkeypatch.setattr("services.scrape_alerts.get_alert_dispatcher", lambda: FakeDispatcher())
+
     mock_page = MagicMock()
     mock_page.status = 404
     mock_page.get_text.return_value = "ページが見つかりません"
@@ -566,12 +575,24 @@ def test_rakuma_patrol_returns_error_on_404(_patch_scrapling):
     patrol = RakumaPatrol()
     result = patrol.fetch("https://item.fril.jp/missing")
 
-    assert not result.success
-    assert result.error == "Rakuma item unavailable (404)"
+    assert result.success
+    assert result.status == "deleted"
+    assert result.error is None
+    assert result.reason == "http-404"
+    assert events == []
 
 
-def test_rakuma_patrol_returns_error_on_missing_item_marker(_patch_scrapling):
-    """RakumaPatrol が not-found 文言を unavailable エラーとして扱うことを確認"""
+def test_rakuma_patrol_returns_deleted_on_missing_item_marker_without_alert(_patch_scrapling, monkeypatch):
+    """RakumaPatrol は missing marker を deleted に正規化し、patrol_error を出さない。"""
+    events = []
+
+    class FakeDispatcher:
+        def notify_scrape_issue(self, **payload):
+            events.append(payload)
+            return True
+
+    monkeypatch.setattr("services.scrape_alerts.get_alert_dispatcher", lambda: FakeDispatcher())
+
     mock_page = MagicMock()
     mock_page.get_text.return_value = "お探しの商品は見つかりません"
     mock_page.css.return_value = []
@@ -582,8 +603,11 @@ def test_rakuma_patrol_returns_error_on_missing_item_marker(_patch_scrapling):
     patrol = RakumaPatrol()
     result = patrol.fetch("https://item.fril.jp/missing")
 
-    assert not result.success
-    assert result.error == "Rakuma item unavailable"
+    assert result.success
+    assert result.status == "deleted"
+    assert result.error is None
+    assert result.reason == "missing-item-marker"
+    assert events == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize Rakuma patrol 404 and missing-item markers to `deleted` instead of `error`
- keep Rakuma patrol aligned with the shared Rakuma parser and repo status semantics
- add coverage for patrol alert suppression and monitor downstream behavior

## Why
Rakuma patrol treated item-unavailable pages as patrol errors, which produced noisy Discord `patrol_error` warnings and caused monitor backoff instead of updating the item status to `deleted`.

## What Changed
- update `services/patrol/rakuma_patrol.py` so HTTP 404 and strong missing-item markers return a successful `PatrolResult(status="deleted")`
- preserve real error handling for actual fetch or parse failures
- add tests that verify:
  - Rakuma patrol does not emit `patrol_error` for 404 or missing-item pages
  - monitor marks the product as `deleted` without incrementing `patrol_fail_count`

## Impact
- reduces false warning noise in Discord for removed Rakuma items
- allows monitor to reflect deleted state correctly and zero inventory downstream
- does not change Mercari `unknown_detail_result` behavior

## Validation
- `pytest tests\test_rakuma_playwright.py tests\test_monitor_service.py tests\test_scrape_alerts.py -q`
- result: `37 passed, 1 warning` (`.pytest_cache` permission warning only)

## Root Cause
The Rakuma shared detail parser already normalized missing items to `deleted`, but the Rakuma patrol path short-circuited those same conditions into `error`, which conflicted with the monitor and alert semantics.

## Risk / Rollout Notes
This change intentionally alters only Rakuma patrol handling for missing-item conditions. It does not suppress warnings generically; it corrects the underlying status semantics so downstream behavior and alerting stay consistent.