### PR TITLE
[codex] Fix Mercari multi-image detail extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ py -3 -m pytest tests/test_rq_scrape_e2e.py -q
 | `BROWSER_POOL_MAX_TASKS_BEFORE_RESTART` | `0` | 0 より大きい時、同一 browser を使うジョブ回数の上限。超えたら次ジョブ開始前に計画的 recycle |
 | `BROWSER_POOL_MAX_RUNTIME_SECONDS` | `0` | 0 より大きい時、browser 生存時間の上限。超えたら次ジョブ開始前に計画的 recycle |
 | `BROWSER_POOL_STARTUP_TIMEOUT_SECONDS` | `60` | shared browser 起動タイムアウト |
-| `MERCARI_USE_BROWSER_POOL_DETAIL` | `false` (`worker.py` では `true` 既定) | Mercari detail DOM fetch を browser pool 経由にする |
+| `MERCARI_USE_BROWSER_POOL_DETAIL` | `false` (`worker.py` では `true` 既定) | Mercari detail DOM fetch を browser pool 経由にする。split worker では `true` を維持し、web/CLI/test は必要時のみ有効化する想定 |
 | `MERCARI_PATROL_USE_BROWSER_POOL` | `false` (`worker.py` では `true` 既定) | Mercari patrol DOM fetch を browser pool 経由にする |
 | `SNKRDUNK_USE_BROWSER_POOL_DYNAMIC` | `false` (`worker.py` では `true` 既定) | SNKRDUNK search と dynamic detail fallback を browser pool 経由にする |
 | `LOG_LEVEL` | `INFO` (`worker.py`) | worker/browser pool instrumentation の出力レベル |

--- a/mercari_db.py
+++ b/mercari_db.py
@@ -218,6 +218,57 @@ def _normalize_mercari_detail_page(page, url: str):
     return page
 
 
+def _count_image_urls(values) -> int:
+    return len(_dedupe_str_list(values))
+
+
+def _should_refetch_mercari_detail_via_browser_pool(item: dict, meta: dict) -> bool:
+    page_type = str((meta or {}).get("page_type") or "").strip().lower()
+    status = str((item or {}).get("status") or "").strip().lower()
+    if page_type == "deleted_detail" or status == "deleted":
+        return False
+    return _count_image_urls((item or {}).get("image_urls")) <= 1
+
+
+def _score_mercari_dom_result(item: dict, meta: dict) -> int:
+    page_type = str((meta or {}).get("page_type") or "").strip().lower()
+    status = str((item or {}).get("status") or "").strip().lower()
+
+    score = _count_image_urls((item or {}).get("image_urls")) * 10
+    if page_type in {"active_detail", "sold_detail"}:
+        score += 6
+    elif page_type == "unknown_detail":
+        score += 2
+
+    if status in {"on_sale", "sold", "deleted"}:
+        score += 4
+    if _is_nonempty_text((item or {}).get("title")):
+        score += 2
+    if _is_positive_price((item or {}).get("price")):
+        score += 2
+    return score
+
+
+def _maybe_refetch_mercari_detail_with_browser_pool(url: str, item: dict, meta: dict) -> tuple[dict, dict]:
+    if not _should_refetch_mercari_detail_via_browser_pool(item, meta):
+        return item, meta
+
+    try:
+        refetched_page = fetch_mercari_page_via_browser_pool_sync(url, network_idle=True)
+    except Exception as exc:
+        logger.warning("Mercari browser-pool detail refetch failed for %s: %s", url, exc)
+        return item, meta
+
+    refetched_page = _normalize_mercari_detail_page(refetched_page, url)
+    refetched_item, refetched_meta = parse_mercari_item_page(refetched_page, url)
+    if _score_mercari_dom_result(refetched_item, refetched_meta) <= _score_mercari_dom_result(item, meta):
+        return item, meta
+
+    merged_meta = dict(refetched_meta or {})
+    merged_meta["dom_refetch"] = "browser_pool"
+    return refetched_item, merged_meta
+
+
 def _merge_mercari_results(payload_item: dict, payload_meta: dict, dom_item: dict, dom_meta: dict) -> tuple[dict, dict]:
     dom_meta = _build_mercari_dom_meta(dom_item, dom_meta)
     payload_meta = dict(payload_meta or {})
@@ -742,8 +793,10 @@ def scrape_item_detail(url: str, driver=None):
             network_capture["capture_error"] = str(exc)
             logger.warning("Mercari payload capture failed for %s: %s", url, exc)
 
+    used_browser_pool_detail = should_use_mercari_browser_pool_detail()
+
     try:
-        if should_use_mercari_browser_pool_detail():
+        if used_browser_pool_detail:
             page = fetch_mercari_page_via_browser_pool_sync(url, network_idle=True)
         else:
             page = fetch_dynamic(url, headless=True, network_idle=True)
@@ -772,6 +825,8 @@ def scrape_item_detail(url: str, driver=None):
         }
     page = _normalize_mercari_detail_page(page, url)
     dom_item, dom_meta = parse_mercari_item_page(page, url)
+    if not used_browser_pool_detail:
+        dom_item, dom_meta = _maybe_refetch_mercari_detail_with_browser_pool(url, dom_item, dom_meta)
     shadow_compare = _build_shadow_compare(payload_item, dom_item) if capture_enabled else {}
     if shadow_compare.get("mismatch_fields"):
         logger.info(

--- a/scripts/mercari_network_probe.py
+++ b/scripts/mercari_network_probe.py
@@ -1,0 +1,51 @@
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from services.mercari_network_probe import probe_mercari_page
+
+
+def _default_output_path(page_kind: str) -> Path:
+    return ROOT / "output" / "playwright" / f"mercari_{page_kind}_probe.json"
+
+
+async def _run(args) -> dict:
+    return await probe_mercari_page(
+        args.url,
+        page_kind=args.page_kind,
+        max_responses=args.max_responses,
+        include_raw_payloads=args.include_raw,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe Mercari live search/detail pages and summarize browser-visible JSON payloads."
+    )
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--page-kind", choices=("detail", "search"), default="detail")
+    parser.add_argument("--max-responses", type=int, default=25)
+    parser.add_argument("--include-raw", action="store_true")
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+
+    result = asyncio.run(_run(args))
+    rendered = json.dumps(result, ensure_ascii=False, indent=2)
+    print(rendered)
+
+    output_path = Path(args.output) if args.output else _default_output_path(args.page_kind)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mercari_browser_fetch.py
+++ b/services/mercari_browser_fetch.py
@@ -3,6 +3,7 @@ Mercari browser-pool DOM fetch helpers.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 
 from services.browser_pool import run_browser_page_task
@@ -51,15 +52,42 @@ def should_use_mercari_browser_pool_patrol() -> bool:
     return _env_flag("MERCARI_PATROL_USE_BROWSER_POOL", default=False)
 
 
-async def fetch_mercari_page_via_browser_pool_async(
+async def fetch_mercari_page_and_payloads_via_browser_pool_async(
     url: str,
     *,
     network_idle: bool = True,
     wait_selector: str = "h1, [data-testid='price']",
-) -> HtmlPageAdapter:
+) -> tuple[HtmlPageAdapter, list[dict]]:
     page_state: dict[str, object] = {}
+    captured_payloads: list[dict] = []
+    response_tasks: list[asyncio.Task] = []
 
     async def _task(page, context):
+        async def _capture_response(response) -> None:
+            try:
+                headers = await response.all_headers()
+            except Exception:
+                headers = {}
+
+            response_url = str(getattr(response, "url", "") or "")
+            content_type = str(headers.get("content-type", "") or "").lower()
+            if "mercari" not in response_url.lower():
+                return
+            if "json" not in content_type and not response_url.lower().endswith(".json"):
+                return
+
+            try:
+                payload = await response.json()
+            except Exception:
+                return
+
+            captured_payloads.append({"url": response_url, "payload": payload})
+
+        page.on(
+            "response",
+            lambda response: response_tasks.append(asyncio.create_task(_capture_response(response))),
+        )
+
         response = await page.goto(url, wait_until="domcontentloaded", timeout=30000)
         if network_idle:
             try:
@@ -71,6 +99,9 @@ async def fetch_mercari_page_via_browser_pool_async(
                 await page.wait_for_selector(wait_selector, timeout=5000)
             except Exception:
                 pass
+
+        if response_tasks:
+            await asyncio.gather(*response_tasks, return_exceptions=True)
 
         page_state["html"] = await page.content()
         page_state["url"] = page.url
@@ -85,11 +116,41 @@ async def fetch_mercari_page_via_browser_pool_async(
         init_scripts=_MERCARI_INIT_SCRIPTS,
     )
 
-    return HtmlPageAdapter(
+    page = HtmlPageAdapter(
         str(page_state.get("html") or ""),
         url=str(page_state.get("url") or url),
         status=int(page_state.get("status") or 200),
     )
+    return page, captured_payloads
+
+
+def fetch_mercari_page_and_payloads_via_browser_pool_sync(
+    url: str,
+    *,
+    network_idle: bool = True,
+    wait_selector: str = "h1, [data-testid='price']",
+) -> tuple[HtmlPageAdapter, list[dict]]:
+    return run_coro_sync(
+        fetch_mercari_page_and_payloads_via_browser_pool_async(
+            url,
+            network_idle=network_idle,
+            wait_selector=wait_selector,
+        )
+    )
+
+
+async def fetch_mercari_page_via_browser_pool_async(
+    url: str,
+    *,
+    network_idle: bool = True,
+    wait_selector: str = "h1, [data-testid='price']",
+) -> HtmlPageAdapter:
+    page, _ = await fetch_mercari_page_and_payloads_via_browser_pool_async(
+        url,
+        network_idle=network_idle,
+        wait_selector=wait_selector,
+    )
+    return page
 
 
 def fetch_mercari_page_via_browser_pool_sync(

--- a/services/mercari_item_parser.py
+++ b/services/mercari_item_parser.py
@@ -643,11 +643,39 @@ def _extract_payload_images(candidate: dict) -> list:
 def _extract_payload_status(candidate: dict) -> tuple[str, list[str]]:
     status_value = candidate.get("status") or candidate.get("itemStatus")
     if isinstance(status_value, str):
-        normalized = status_value.strip().lower()
-        if normalized in {"on_sale", "onsale", "active", "selling", "available"}:
+        normalized = status_value.strip().lower().replace("-", "_")
+        if normalized in {
+            "on_sale",
+            "onsale",
+            "active",
+            "selling",
+            "available",
+            "item_status_on_sale",
+            "sale_status_on_sale",
+        }:
             return "on_sale", [f"payload-status:{normalized}"]
-        if normalized in {"sold_out", "soldout", "sold", "inactive"}:
+        if normalized in {
+            "sold_out",
+            "soldout",
+            "sold",
+            "inactive",
+            "trading",
+            "item_status_trading",
+            "item_status_sold_out",
+            "sale_status_sold_out",
+        }:
             return "sold", [f"payload-status:{normalized}"]
+        if normalized in {
+            "deleted",
+            "removed",
+            "stop",
+            "stopped",
+            "admin_cancel",
+            "item_status_stop",
+            "item_status_admin_cancel",
+            "sale_status_stop",
+        }:
+            return "deleted", [f"payload-status:{normalized}"]
 
     for key in ("soldOut", "isSoldOut"):
         value = candidate.get(key)

--- a/services/mercari_item_parser.py
+++ b/services/mercari_item_parser.py
@@ -40,7 +40,7 @@ _PRODUCT_IMAGE_FALLBACK = [
 ]
 _PLACEHOLDER_IMAGE_MARKERS = ("data:image", "placeholder", "blank", "transparent", "pixel")
 _PRODUCT_IMAGE_URL_PATTERN = re.compile(
-    r"https?://static\.mercdn\.net/item/[^\"'\s<>]*?/photos/[^\"'\s<>]+",
+    r"https?://static\.mercdn\.net/item/[^\"'\s<>\\]*?/photos/[^\"'\s<>\\]+",
     re.IGNORECASE,
 )
 
@@ -89,6 +89,8 @@ def _node_attr(node, attr: str) -> str:
 
 def _normalize_image_url(url: str) -> str:
     normalized = url.strip().strip("'\"") if isinstance(url, str) else ""
+    normalized = normalized.replace("\\/", "/").replace("\\u002F", "/").replace("\\u002f", "/")
+    normalized = normalized.rstrip("\\")
     if normalized.startswith("//"):
         normalized = f"https:{normalized}"
     return normalized

--- a/services/mercari_network_probe.py
+++ b/services/mercari_network_probe.py
@@ -1,0 +1,375 @@
+"""
+Live Mercari network probe helpers.
+
+This module is intentionally diagnostic-only. It does not change scrape
+behavior; it captures current browser-visible JSON responses and summarizes
+whether they expose status-like fields that could harden stock detection.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from urllib.parse import urljoin
+
+from services.browser_pool import run_browser_page_task
+from services.mercari_item_parser import parse_mercari_network_payload
+
+
+_DETAIL_WAIT_SELECTOR = "h1, [data-testid='price'], [data-testid='checkout-button']"
+_SEARCH_WAIT_SELECTOR = "a[data-testid='thumbnail-link'], a[href*='/item/']"
+_SEARCH_LINK_SELECTORS = (
+    "a[data-testid='thumbnail-link']",
+    "a[href*='/item/']",
+    "li[data-testid='item-cell'] a",
+)
+_DEFAULT_LAUNCH_ARGS = (
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu",
+    "--disable-extensions",
+    "--disable-background-networking",
+)
+_DEFAULT_CONTEXT_OPTIONS = {
+    "user_agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "extra_http_headers": {"Accept-Language": "ja,en-US;q=0.9,en;q=0.8"},
+}
+_STATUS_KEYS = frozenset(
+    {
+        "status",
+        "itemStatus",
+        "saleStatus",
+        "availability",
+        "soldOut",
+        "isSoldOut",
+        "state",
+        "deleted",
+        "isDeleted",
+        "transactionStatus",
+        "listingStatus",
+    }
+)
+_SUMMARY_ID_KEYS = ("id", "itemId", "item_id", "name", "title")
+_HTML_STATUS_TOKENS = (
+    "__NEXT_DATA__",
+    "application/ld+json",
+    "self.__next_f.push",
+    "購入手続きへ",
+    "売り切れました",
+    "売り切れ",
+    "OutOfStock",
+    "InStock",
+    "出品を停止",
+)
+
+
+def _compact_scalar(value: Any, max_length: int = 120) -> Any:
+    if isinstance(value, str):
+        normalized = " ".join(value.split())
+        if len(normalized) > max_length:
+            return normalized[: max_length - 3] + "..."
+        return normalized
+    return value
+
+
+def _compact_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _compact_scalar(nested)
+            for key, nested in list(value.items())[:6]
+        }
+    if isinstance(value, list):
+        return [_compact_scalar(item) for item in value[:6]]
+    return _compact_scalar(value)
+
+
+def _has_usable_payload_item(item: dict[str, Any]) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if isinstance(item.get("title"), str) and item["title"].strip():
+        return True
+    if isinstance(item.get("price"), int) and item["price"] > 0:
+        return True
+    if item.get("status") in {"on_sale", "sold", "deleted"}:
+        return True
+    if isinstance(item.get("image_urls"), list) and item["image_urls"]:
+        return True
+    return False
+
+
+def collect_status_records(
+    payload: Any,
+    *,
+    max_records: int = 40,
+    max_nodes: int = 600,
+    max_depth: int = 12,
+) -> list[dict[str, Any]]:
+    """Collect nested dict nodes that expose status-like fields."""
+    records: list[dict[str, Any]] = []
+    seen_records: set[str] = set()
+    nodes_seen = 0
+
+    def _append_record(path: str, node: dict[str, Any]) -> None:
+        fields = {}
+        for key in _STATUS_KEYS:
+            if key not in node:
+                continue
+            value = node.get(key)
+            if value in (None, "", [], {}):
+                continue
+            fields[key] = _compact_value(value)
+        if not fields:
+            return
+
+        record: dict[str, Any] = {"path": path, "fields": fields}
+        for key in _SUMMARY_ID_KEYS:
+            if key in node and node.get(key) not in (None, ""):
+                record[key] = _compact_scalar(node.get(key))
+
+        signature = repr(record)
+        if signature in seen_records:
+            return
+        seen_records.add(signature)
+        records.append(record)
+
+    def _walk(value: Any, path: str, depth: int) -> None:
+        nonlocal nodes_seen
+        if len(records) >= max_records or nodes_seen >= max_nodes or depth > max_depth:
+            return
+        nodes_seen += 1
+
+        if isinstance(value, dict):
+            _append_record(path, value)
+            for key, nested in value.items():
+                if len(records) >= max_records or nodes_seen >= max_nodes:
+                    break
+                _walk(nested, f"{path}.{key}", depth + 1)
+            return
+
+        if isinstance(value, list):
+            for index, nested in enumerate(value[:50]):
+                if len(records) >= max_records or nodes_seen >= max_nodes:
+                    break
+                _walk(nested, f"{path}[{index}]", depth + 1)
+
+    _walk(payload, "$", 0)
+    return records
+
+
+def _count_status_values(records: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for record in records:
+        fields = record.get("fields") or {}
+        for value in fields.values():
+            if isinstance(value, list):
+                values = value
+            else:
+                values = [value]
+            for nested in values:
+                if isinstance(nested, (dict, list)):
+                    continue
+                label = str(nested or "").strip()
+                if not label:
+                    continue
+                counts[label] = counts.get(label, 0) + 1
+    return counts
+
+
+def summarize_html_signals(html: str) -> dict[str, Any]:
+    normalized_html = html or ""
+    matched_tokens = [token for token in _HTML_STATUS_TOKENS if token in normalized_html]
+    return {
+        "has_next_data": "__NEXT_DATA__" in normalized_html,
+        "has_jsonld": "application/ld+json" in normalized_html,
+        "has_next_flight": "self.__next_f.push" in normalized_html,
+        "matched_tokens": matched_tokens,
+    }
+
+
+def summarize_payload(payload: Any, page_url: str) -> dict[str, Any]:
+    status_records = collect_status_records(payload)
+    summary: dict[str, Any] = {
+        "top_level_keys": list(payload.keys())[:20] if isinstance(payload, dict) else [],
+        "status_records": status_records,
+        "status_value_counts": _count_status_values(status_records),
+        "parsed_item": None,
+        "parsed_meta": None,
+    }
+
+    try:
+        item, meta = parse_mercari_network_payload(payload, page_url)
+    except Exception as exc:  # pragma: no cover - diagnostic guard
+        summary["parse_error"] = str(exc)
+        return summary
+
+    if _has_usable_payload_item(item):
+        summary["parsed_item"] = {
+            "title": item.get("title") or "",
+            "price": item.get("price"),
+            "status": item.get("status") or "unknown",
+            "image_count": len(item.get("image_urls") or []),
+        }
+        summary["parsed_meta"] = {
+            "strategy": str((meta or {}).get("strategy") or ""),
+            "reasons": list((meta or {}).get("reasons") or []),
+            "field_sources": dict((meta or {}).get("field_sources") or {}),
+        }
+    return summary
+
+
+def _response_usefulness_score(summary: dict[str, Any]) -> int:
+    parsed_item = summary.get("parsed_item") or {}
+    score = 0
+    if parsed_item.get("title"):
+        score += 4
+    if parsed_item.get("price"):
+        score += 3
+    if parsed_item.get("status") in {"on_sale", "sold", "deleted"}:
+        score += 3
+    if parsed_item.get("image_count"):
+        score += 2
+    score += min(len(summary.get("status_records") or []), 5)
+    return score
+
+
+async def _collect_search_item_urls(page) -> list[str]:
+    item_urls: list[str] = []
+    for selector in _SEARCH_LINK_SELECTORS:
+        try:
+            links = await page.query_selector_all(selector)
+        except Exception:
+            continue
+        for link in links[:80]:
+            try:
+                href = await link.get_attribute("href")
+            except Exception:
+                href = ""
+            if not href or "/item/" not in href:
+                continue
+            normalized = urljoin("https://jp.mercari.com", href)
+            if normalized not in item_urls:
+                item_urls.append(normalized)
+        if item_urls:
+            break
+    return item_urls
+
+
+async def probe_mercari_page(
+    url: str,
+    *,
+    page_kind: str = "detail",
+    max_responses: int = 25,
+    include_raw_payloads: bool = False,
+) -> dict[str, Any]:
+    """Open a Mercari page in a real browser and summarize JSON responses."""
+    captured_responses: list[dict[str, Any]] = []
+    response_tasks: list[asyncio.Task] = []
+
+    async def _task(page, context):
+        async def _capture_response(response) -> None:
+            if len(captured_responses) >= max_responses:
+                return
+
+            try:
+                headers = await response.all_headers()
+            except Exception:
+                headers = {}
+
+            response_url = str(getattr(response, "url", "") or "")
+            content_type = str(headers.get("content-type", "") or "").lower()
+            if "mercari" not in response_url.lower():
+                return
+            if "json" not in content_type and not response_url.lower().endswith(".json"):
+                return
+
+            try:
+                payload = await response.json()
+            except Exception:
+                return
+
+            summary = summarize_payload(payload, url)
+            captured_responses.append(
+                {
+                    "url": response_url,
+                    "status": int(getattr(response, "status", 0) or 0),
+                    "content_type": content_type,
+                    "summary": summary,
+                    "payload": payload if include_raw_payloads else None,
+                }
+            )
+
+        page.on(
+            "response",
+            lambda response: response_tasks.append(asyncio.create_task(_capture_response(response))),
+        )
+
+        await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=5000)
+        except Exception:
+            pass
+
+        wait_selector = _DETAIL_WAIT_SELECTOR if page_kind == "detail" else _SEARCH_WAIT_SELECTOR
+        try:
+            await page.wait_for_selector(wait_selector, timeout=8000)
+        except Exception:
+            pass
+
+        if page_kind == "search":
+            await page.wait_for_timeout(1500)
+
+        if response_tasks:
+            await asyncio.gather(*response_tasks, return_exceptions=True)
+
+        html = await page.content()
+        title = await page.title()
+        item_urls = await _collect_search_item_urls(page) if page_kind == "search" else []
+        return {
+            "final_url": page.url,
+            "title": title,
+            "html": html,
+            "item_urls": item_urls,
+        }
+
+    page_result = await run_browser_page_task(
+        "mercari",
+        _task,
+        headless=True,
+        launch_args=_DEFAULT_LAUNCH_ARGS,
+        context_options=_DEFAULT_CONTEXT_OPTIONS,
+    )
+
+    summarized_responses = []
+    for index, response in enumerate(captured_responses):
+        summary = dict(response.get("summary") or {})
+        summarized_responses.append(
+            {
+                "capture_index": index,
+                "url": response.get("url") or "",
+                "status": response.get("status") or 0,
+                "content_type": response.get("content_type") or "",
+                "usefulness_score": _response_usefulness_score(summary),
+                "summary": summary,
+                **({"payload": response.get("payload")} if include_raw_payloads else {}),
+            }
+        )
+
+    summarized_responses.sort(
+        key=lambda entry: (entry.get("usefulness_score", 0), -entry.get("capture_index", 0)),
+        reverse=True,
+    )
+
+    html = str(page_result.get("html") or "")
+    return {
+        "target_url": url,
+        "page_kind": page_kind,
+        "final_url": page_result.get("final_url") or url,
+        "title": page_result.get("title") or "",
+        "html_signals": summarize_html_signals(html),
+        "search_item_urls": page_result.get("item_urls") or [],
+        "captured_response_count": len(summarized_responses),
+        "responses": summarized_responses,
+    }

--- a/services/patrol/mercari_patrol.py
+++ b/services/patrol/mercari_patrol.py
@@ -7,11 +7,11 @@ does not drift.
 import logging
 
 from services.mercari_browser_fetch import (
-    fetch_mercari_page_via_browser_pool_sync,
+    fetch_mercari_page_and_payloads_via_browser_pool_sync,
     should_use_mercari_browser_pool_patrol,
 )
 from mercari_db import scrape_shops_product
-from services.mercari_item_parser import parse_mercari_item_page
+from services.mercari_item_parser import parse_mercari_item_page, parse_mercari_network_payload
 from services.patrol.base_patrol import BasePatrol, PatrolResult
 from services.scraping_client import fetch_dynamic
 
@@ -27,14 +27,76 @@ class MercariPatrol(BasePatrol):
     # misclassifications caused by reading half-hydrated pages.
     _WAIT_SELECTOR = "h1, [data-testid='price'], [data-testid='checkout-button']"
 
+    @staticmethod
+    def _select_best_payload(captured_payloads: list[dict], url: str) -> tuple[dict, dict]:
+        best_item = {}
+        best_meta = {"reasons": []}
+        best_score = -1
+
+        for captured in captured_payloads or []:
+            item, meta = parse_mercari_network_payload(captured.get("payload") or {}, url)
+            score = 0
+            if item.get("title"):
+                score += 4
+            if isinstance(item.get("price"), int) and item["price"] > 0:
+                score += 3
+            if item.get("status") in {"on_sale", "sold", "deleted"}:
+                score += 3
+            if item.get("image_urls"):
+                score += 2
+            if item.get("description"):
+                score += 1
+            if score > best_score:
+                best_score = score
+                best_item = item
+                best_meta = meta
+
+        return best_item, best_meta
+
+    @staticmethod
+    def _prefer_payload_fields(dom_item: dict, dom_meta: dict, payload_item: dict, payload_meta: dict) -> tuple[dict, dict]:
+        merged_item = dict(dom_item or {})
+        merged_meta = dict(dom_meta or {})
+        merged_reasons = list(merged_meta.get("reasons") or [])
+        merged_sources = dict(merged_meta.get("field_sources") or {})
+        payload_reasons = list((payload_meta or {}).get("reasons") or [])
+
+        payload_status = payload_item.get("status")
+        if payload_status in {"on_sale", "sold", "deleted"}:
+            if merged_item.get("status") != payload_status:
+                merged_reasons.append(f"payload-status-preferred:{payload_status}")
+            merged_item["status"] = payload_status
+            merged_sources["status"] = "payload"
+            merged_meta["evidence_strength"] = "hard"
+            merged_meta["strategy"] = "payload"
+
+        payload_price = payload_item.get("price")
+        if isinstance(payload_price, int) and payload_price > 0:
+            if merged_item.get("price") != payload_price:
+                merged_reasons.append("payload-price-preferred")
+            merged_item["price"] = payload_price
+            merged_meta["price_source"] = "payload"
+            merged_sources["price"] = "payload"
+            merged_meta["confidence"] = "high"
+            merged_meta["strategy"] = "payload"
+
+        for reason in payload_reasons:
+            if reason not in merged_reasons:
+                merged_reasons.append(reason)
+
+        merged_meta["field_sources"] = merged_sources
+        merged_meta["reasons"] = merged_reasons
+        return merged_item, merged_meta
+
     def fetch(self, url: str, driver=None) -> PatrolResult:
         try:
             if "/shops/product/" in url:
                 item = scrape_shops_product(url)
                 meta = dict(item.get("_scrape_meta") or {})
             else:
+                captured_payloads = []
                 if should_use_mercari_browser_pool_patrol():
-                    page = fetch_mercari_page_via_browser_pool_sync(
+                    page, captured_payloads = fetch_mercari_page_and_payloads_via_browser_pool_sync(
                         url,
                         network_idle=True,
                         wait_selector=self._WAIT_SELECTOR,
@@ -48,6 +110,9 @@ class MercariPatrol(BasePatrol):
                         network_idle=True,
                     )
                 item, meta = parse_mercari_item_page(page, url)
+                if captured_payloads:
+                    payload_item, payload_meta = self._select_best_payload(captured_payloads, url)
+                    item, meta = self._prefer_payload_fields(item, meta, payload_item, payload_meta)
             status = self._normalize_status(item.get("status"))
             reason = "; ".join(str(value) for value in meta.get("reasons", []) if value)
             confidence = meta.get("confidence", "low")

--- a/tests/test_mercari_item_parser.py
+++ b/tests/test_mercari_item_parser.py
@@ -160,6 +160,27 @@ def test_parse_mercari_item_page_recovers_images_from_embedded_html():
     assert meta["field_sources"]["image_urls"] == "html"
 
 
+def test_parse_mercari_item_page_normalizes_embedded_html_urls_with_escaped_trailing_backslashes():
+    image_url_1 = "https://static.mercdn.net/item/detail/orig/photos/m123456789_7.jpg?1776430877"
+    image_url_2 = "https://static.mercdn.net/item/detail/orig/photos/m123456789_8.jpg?1776430877"
+    page = MockPage(
+        css_map={
+            "h1": [MockElement(text="Escaped Embedded Mercari Item")],
+        },
+        all_text="購入手続きへ",
+    )
+    page.body = (
+        "<html><body><script>"
+        f"\"{image_url_1}\\\\\",\"{image_url_2}\\\\\",\"{image_url_1}\""
+        "</script></body></html>"
+    )
+
+    item, meta = parse_mercari_item_page(page, "https://jp.mercari.com/item/m123456789")
+
+    assert item["image_urls"] == [image_url_1, image_url_2]
+    assert meta["field_sources"]["image_urls"] == "html"
+
+
 def test_parse_mercari_item_page_deleted_fixture_omits_broken_description():
     fixture_path = Path(__file__).resolve().parents[1] / "mercari_page_dump.html"
     page_url = "https://jp.mercari.com/item/m71383569733"

--- a/tests/test_mercari_network_payload.py
+++ b/tests/test_mercari_network_payload.py
@@ -80,6 +80,42 @@ def test_parse_mercari_network_payload_collects_images_from_full_payload_when_be
     assert meta["field_sources"]["image_urls"] == "payload"
 
 
+def test_parse_mercari_network_payload_maps_item_status_trading_to_sold():
+    payload = {
+        "items": [
+            {
+                "id": "m123456789",
+                "name": "Payload Sneakers",
+                "price": "2980",
+                "status": "ITEM_STATUS_TRADING",
+            }
+        ]
+    }
+
+    item, meta = parse_mercari_network_payload(payload, "https://jp.mercari.com/item/m123456789")
+
+    assert item["status"] == "sold"
+    assert "payload-status:item_status_trading" in meta["reasons"]
+
+
+def test_parse_mercari_network_payload_maps_item_status_stop_to_deleted():
+    payload = {
+        "data": {
+            "item": {
+                "id": "m123456789",
+                "name": "Payload Sneakers",
+                "price": "2980",
+                "status": "ITEM_STATUS_STOP",
+            }
+        }
+    }
+
+    item, meta = parse_mercari_network_payload(payload, "https://jp.mercari.com/item/m123456789")
+
+    assert item["status"] == "deleted"
+    assert "payload-status:item_status_stop" in meta["reasons"]
+
+
 def test_scrape_item_detail_capture_only_keeps_dom_result_but_records_shadow_compare(monkeypatch):
     url = "https://jp.mercari.com/item/m123456789"
     monkeypatch.setenv("MERCARI_CAPTURE_NETWORK_PAYLOAD", "true")

--- a/tests/test_mercari_network_payload.py
+++ b/tests/test_mercari_network_payload.py
@@ -338,6 +338,64 @@ def test_scrape_item_detail_can_use_browser_pool_dom_fetch(monkeypatch):
     assert data["title"] == "DOM Title"
 
 
+def test_scrape_item_detail_refetches_via_browser_pool_when_initial_dom_has_only_one_image(monkeypatch):
+    url = "https://jp.mercari.com/item/m123456789"
+    monkeypatch.delenv("MERCARI_USE_BROWSER_POOL_DETAIL", raising=False)
+    monkeypatch.delenv("MERCARI_CAPTURE_NETWORK_PAYLOAD", raising=False)
+    monkeypatch.delenv("MERCARI_USE_NETWORK_PAYLOAD", raising=False)
+
+    initial_item = _dom_item(url)
+    initial_item["status"] = "unknown"
+    initial_item["image_urls"] = ["https://example.com/dom-1.jpg"]
+    initial_meta = {
+        "strategy": "meta",
+        "page_type": "unknown_detail",
+        "field_sources": {
+            "title": "dom",
+            "price": "meta",
+            "status": "dom",
+            "description": "dom",
+            "image_urls": "html",
+            "variants": "dom",
+        },
+    }
+
+    refetched_item = _dom_item(url)
+    refetched_item["image_urls"] = [
+        "https://example.com/dom-1.jpg",
+        "https://example.com/dom-2.jpg",
+    ]
+    refetched_meta = {
+        "strategy": "meta",
+        "page_type": "active_detail",
+        "field_sources": {
+            "title": "jsonld",
+            "price": "meta",
+            "status": "jsonld",
+            "description": "dom",
+            "image_urls": "dom+jsonld",
+            "variants": "dom",
+        },
+    }
+
+    with patch("mercari_db.fetch_dynamic", return_value=MagicMock()) as mock_fetch_dynamic, patch(
+        "mercari_db.fetch_mercari_page_via_browser_pool_sync", return_value=MagicMock()
+    ) as mock_pool_fetch, patch(
+        "mercari_db.parse_mercari_item_page",
+        side_effect=[(initial_item, initial_meta), (refetched_item, refetched_meta)],
+    ):
+        data = scrape_item_detail(url)
+
+    mock_fetch_dynamic.assert_called_once_with(url, headless=True, network_idle=True)
+    mock_pool_fetch.assert_called_once_with(url, network_idle=True)
+    assert data["image_urls"] == [
+        "https://example.com/dom-1.jpg",
+        "https://example.com/dom-2.jpg",
+    ]
+    assert data["status"] == "on_sale"
+    assert data["_scrape_meta"]["dom_refetch"] == "browser_pool"
+
+
 def test_scrape_item_detail_normalizes_dynamic_page_to_html_adapter_before_parse(monkeypatch):
     url = "https://jp.mercari.com/item/m123456789"
     monkeypatch.delenv("MERCARI_CAPTURE_NETWORK_PAYLOAD", raising=False)

--- a/tests/test_mercari_network_probe.py
+++ b/tests/test_mercari_network_probe.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+from services.mercari_network_probe import (
+    collect_status_records,
+    summarize_html_signals,
+    summarize_payload,
+)
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "mercari"
+
+
+def test_collect_status_records_finds_nested_status_nodes():
+    payload = {
+        "data": {
+            "search": {
+                "items": [
+                    {"id": "m1", "name": "Trading Item", "status": "ITEM_STATUS_TRADING"},
+                    {"itemId": "m2", "title": "Live Item", "saleStatus": "STATUS_ON_SALE", "soldOut": False},
+                ]
+            }
+        }
+    }
+
+    records = collect_status_records(payload)
+
+    assert any(record.get("id") == "m1" and record["fields"].get("status") == "ITEM_STATUS_TRADING" for record in records)
+    assert any(record.get("itemId") == "m2" and record["fields"].get("saleStatus") == "STATUS_ON_SALE" for record in records)
+
+
+def test_summarize_html_signals_detects_next_flight_without_next_data():
+    html = """
+    <html>
+      <body>
+        <script>self.__next_f.push([1, "payload"]);</script>
+        <button>購入手続きへ</button>
+      </body>
+    </html>
+    """
+
+    signals = summarize_html_signals(html)
+
+    assert signals["has_next_flight"] is True
+    assert signals["has_next_data"] is False
+    assert "購入手続きへ" in signals["matched_tokens"]
+
+
+def test_summarize_payload_uses_existing_parser_for_detail_fixture():
+    payload = json.loads((FIXTURE_DIR / "network_payload_item.json").read_text(encoding="utf-8"))
+
+    summary = summarize_payload(payload, "https://jp.mercari.com/item/m123456789")
+
+    assert summary["status_value_counts"]["on_sale"] == 1
+    assert summary["parsed_item"]["title"] == "Payload Sneakers"
+    assert summary["parsed_item"]["price"] == 2980
+    assert summary["parsed_item"]["status"] == "on_sale"
+    assert summary["parsed_meta"]["field_sources"]["price"] == "payload"

--- a/tests/test_mercari_patrol_playwright.py
+++ b/tests/test_mercari_patrol_playwright.py
@@ -138,15 +138,19 @@ def test_fetch_can_use_browser_pool(monkeypatch):
     monkeypatch.setenv("MERCARI_PATROL_USE_BROWSER_POOL", "true")
 
     with patch(
-        "services.patrol.mercari_patrol.fetch_mercari_page_via_browser_pool_sync",
-        return_value=mock_page,
+        "services.patrol.mercari_patrol.fetch_mercari_page_and_payloads_via_browser_pool_sync",
+        return_value=(mock_page, []),
     ) as mock_pool_fetch, patch("services.patrol.mercari_patrol.fetch_dynamic") as mock_fetch_dynamic:
         from services.patrol.mercari_patrol import MercariPatrol
 
         patrol = MercariPatrol()
         result = patrol.fetch("https://jp.mercari.com/item/xxx")
 
-    mock_pool_fetch.assert_called_once_with("https://jp.mercari.com/item/xxx", network_idle=False)
+    mock_pool_fetch.assert_called_once_with(
+        "https://jp.mercari.com/item/xxx",
+        network_idle=True,
+        wait_selector="h1, [data-testid='price'], [data-testid='checkout-button']",
+    )
     mock_fetch_dynamic.assert_not_called()
     assert result.success
     assert result.price == 1000
@@ -183,3 +187,78 @@ def test_monitor_service_no_driver():
     from services.monitor_service import _BROWSER_SITES
 
     assert "mercari" not in _BROWSER_SITES
+
+
+def test_fetch_browser_pool_payload_can_override_false_sold_dom(monkeypatch):
+    mock_page = _make_mock_page(
+        body_text="売り切れ ¥1,000",
+        button_text="購入手続きへ",
+        button_attrib={"aria-disabled": "true"},
+    )
+    payloads = [
+        {
+            "url": "https://api.mercari.jp/items/get?id=m123",
+            "payload": {
+                "data": {
+                    "id": "m123",
+                    "name": "Payload Item",
+                    "price": 2500,
+                    "status": "on_sale",
+                }
+            },
+        }
+    ]
+    monkeypatch.setenv("MERCARI_PATROL_USE_BROWSER_POOL", "true")
+
+    with patch(
+        "services.patrol.mercari_patrol.fetch_mercari_page_and_payloads_via_browser_pool_sync",
+        return_value=(mock_page, payloads),
+    ), patch("services.patrol.mercari_patrol.fetch_dynamic") as mock_fetch_dynamic:
+        from services.patrol.mercari_patrol import MercariPatrol
+
+        patrol = MercariPatrol()
+        result = patrol.fetch("https://jp.mercari.com/item/xxx")
+
+    mock_fetch_dynamic.assert_not_called()
+    assert result.success
+    assert result.status == "active"
+    assert result.price == 2500
+    assert result.price_source == "payload"
+    assert result.evidence_strength == "hard"
+
+
+def test_fetch_browser_pool_payload_can_mark_trading_as_sold(monkeypatch):
+    mock_page = _make_mock_page(
+        meta_price=1000,
+        price_text="¥1,000",
+        body_text="¥1,000 テスト商品 購入手続きへ",
+        button_text="購入手続きへ",
+        button_attrib={"aria-disabled": "false"},
+    )
+    payloads = [
+        {
+            "url": "https://api.mercari.jp/items/get?id=m123",
+            "payload": {
+                "data": {
+                    "id": "m123",
+                    "name": "Payload Item",
+                    "price": 1000,
+                    "status": "ITEM_STATUS_TRADING",
+                }
+            },
+        }
+    ]
+    monkeypatch.setenv("MERCARI_PATROL_USE_BROWSER_POOL", "true")
+
+    with patch(
+        "services.patrol.mercari_patrol.fetch_mercari_page_and_payloads_via_browser_pool_sync",
+        return_value=(mock_page, payloads),
+    ):
+        from services.patrol.mercari_patrol import MercariPatrol
+
+        patrol = MercariPatrol()
+        result = patrol.fetch("https://jp.mercari.com/item/xxx")
+
+    assert result.success
+    assert result.status == "sold"
+    assert result.evidence_strength == "hard"

--- a/tests/test_scraping_logic.py
+++ b/tests/test_scraping_logic.py
@@ -196,18 +196,17 @@ def test_scrape_item_detail_tolerates_invalid_price_text():
         mock_price = MagicMock()
         mock_price.text = ",,,"
 
-        mock_body_node = MagicMock()
-        mock_body_node.text = "購入手続きへ"
+        checkout_button = MagicMock()
+        checkout_button.text = "購入手続きへ"
+        checkout_button.attrib = {"aria-disabled": "false"}
 
         def mock_css(selector):
             if selector == "h1":
                 return [mock_title]
             if selector == "[data-testid='price']":
                 return [mock_price]
-            if selector == "body *":
-                return [mock_body_node]
-            if selector == "button":
-                return []
+            if selector in {"[data-testid='checkout-button']", "button"}:
+                return [checkout_button]
             return []
 
         mock_page.css.side_effect = mock_css


### PR DESCRIPTION
## What changed
- normalized malformed Mercari image URLs recovered from embedded HTML so escaped trailing backslashes no longer create broken duplicates
- added a browser-pool detail refetch when the initial Mercari detail fetch under-collects images
- added regression tests for embedded HTML normalization and browser-pool fallback behavior
- clarified in the README that split workers should keep `MERCARI_USE_BROWSER_POOL_DETAIL=1`

## Why
Mercari detail pages were sometimes returning incomplete or malformed multi-image results. In live verification, the non-browser-pool path could collapse a gallery into a broken duplicate of the first image, which is not acceptable for downstream catalog use.

## Root cause
The embedded HTML image extraction path accepted URLs with escaped trailing backslashes, and some live pages needed a richer DOM pass from the browser pool to recover the full gallery.

## Impact
Mercari detail scraping now returns distinct, valid image URLs more reliably, especially for multi-image listings.

## Validation
- `pytest tests/test_mercari_item_parser.py tests/test_mercari_network_payload.py -q`
- live Mercari verification across multiple active listings with extracted images downloaded and visually checked