### PR TITLE
fix: scope description templates by user

### DIFF
--- a/alembic/versions/20260420_0006_add_translation_suggestions.py
+++ b/alembic/versions/20260420_0006_add_translation_suggestions.py
@@ -26,23 +26,24 @@ def _product_column_names(inspector) -> set[str]:
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-
-    product_columns = _product_column_names(inspector)
-    with op.batch_alter_table("products") as batch:
-        if "custom_title_en_source_hash" not in product_columns:
-            batch.add_column(
-                sa.Column("custom_title_en_source_hash", sa.String(length=64), nullable=True)
-            )
-        if "custom_description_en_source_hash" not in product_columns:
-            batch.add_column(
-                sa.Column(
-                    "custom_description_en_source_hash",
-                    sa.String(length=64),
-                    nullable=True,
-                )
-            )
-
     existing_tables = set(inspector.get_table_names())
+
+    if "products" in existing_tables:
+        product_columns = _product_column_names(inspector)
+        with op.batch_alter_table("products") as batch:
+            if "custom_title_en_source_hash" not in product_columns:
+                batch.add_column(
+                    sa.Column("custom_title_en_source_hash", sa.String(length=64), nullable=True)
+                )
+            if "custom_description_en_source_hash" not in product_columns:
+                batch.add_column(
+                    sa.Column(
+                        "custom_description_en_source_hash",
+                        sa.String(length=64),
+                        nullable=True,
+                    )
+                )
+
     if "translation_suggestions" not in existing_tables:
         op.create_table(
             "translation_suggestions",
@@ -120,9 +121,10 @@ def downgrade() -> None:
                 op.drop_index(index_name, table_name="translation_suggestions")
         op.drop_table("translation_suggestions")
 
-    product_columns = _product_column_names(inspector)
-    with op.batch_alter_table("products") as batch:
-        if "custom_description_en_source_hash" in product_columns:
-            batch.drop_column("custom_description_en_source_hash")
-        if "custom_title_en_source_hash" in product_columns:
-            batch.drop_column("custom_title_en_source_hash")
+    if "products" in existing_tables:
+        product_columns = _product_column_names(inspector)
+        with op.batch_alter_table("products") as batch:
+            if "custom_description_en_source_hash" in product_columns:
+                batch.drop_column("custom_description_en_source_hash")
+            if "custom_title_en_source_hash" in product_columns:
+                batch.drop_column("custom_title_en_source_hash")

--- a/alembic/versions/20260422_0006_add_description_template_user_scope.py
+++ b/alembic/versions/20260422_0006_add_description_template_user_scope.py
@@ -1,0 +1,89 @@
+"""add user scope to description templates
+
+Revision ID: 20260422_0006
+Revises: 20260420_0007
+Create Date: 2026-04-22 00:06:00
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260422_0006"
+down_revision = "20260420_0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if "description_templates" not in existing_tables:
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns("description_templates")}
+    existing_indexes = {index["name"] for index in inspector.get_indexes("description_templates")}
+    existing_unique_constraints = [
+        constraint
+        for constraint in inspector.get_unique_constraints("description_templates")
+        if constraint.get("name")
+    ]
+    legacy_name_unique_constraints = [
+        str(constraint["name"])
+        for constraint in existing_unique_constraints
+        if list(constraint.get("column_names") or []) == ["name"]
+    ]
+    scoped_name_unique_present = any(
+        list(constraint.get("column_names") or []) == ["user_id", "name"]
+        for constraint in existing_unique_constraints
+    )
+    user_id_present = "user_id" in existing_columns
+
+    with op.batch_alter_table("description_templates") as batch_op:
+        if not user_id_present:
+            batch_op.add_column(sa.Column("user_id", sa.Integer(), nullable=True))
+            batch_op.create_foreign_key(
+                "fk_description_templates_user_id_users",
+                "users",
+                ["user_id"],
+                ["id"],
+            )
+            user_id_present = True
+        if "ix_description_templates_user_id" not in existing_indexes:
+            batch_op.create_index("ix_description_templates_user_id", ["user_id"], unique=False)
+        for constraint_name in legacy_name_unique_constraints:
+            batch_op.drop_constraint(constraint_name, type_="unique")
+        if not scoped_name_unique_present:
+            batch_op.create_unique_constraint(
+                "uq_description_templates_user_name",
+                ["user_id", "name"],
+            )
+
+    if user_id_present and "users" in existing_tables:
+        user_ids = list(bind.execute(sa.text("SELECT id FROM users ORDER BY id")).scalars())
+        if len(user_ids) == 1:
+            bind.execute(
+                sa.text(
+                    "UPDATE description_templates "
+                    "SET user_id = :user_id "
+                    "WHERE user_id IS NULL"
+                ),
+                {"user_id": user_ids[0]},
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if "description_templates" not in existing_tables:
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("description_templates")}
+    if "ix_description_templates_user_id" in existing_indexes:
+        with op.batch_alter_table("description_templates") as batch_op:
+            batch_op.drop_index("ix_description_templates_user_id")
+
+    # Leave the additive column in place for compatibility with older rows.

--- a/database.py
+++ b/database.py
@@ -71,6 +71,7 @@ ADDITIVE_STARTUP_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
     ("price_lists", "theme", "ALTER TABLE price_lists ADD COLUMN theme VARCHAR DEFAULT 'dark'"),
     ("price_lists", "shop_id", "ALTER TABLE price_lists ADD COLUMN shop_id INTEGER"),
     ("shops", "logo_url", "ALTER TABLE shops ADD COLUMN logo_url VARCHAR"),
+    ("description_templates", "user_id", "ALTER TABLE description_templates ADD COLUMN user_id INTEGER"),
     ("products", "patrol_fail_count", "ALTER TABLE products ADD COLUMN patrol_fail_count INTEGER DEFAULT 0"),
     ("scrape_jobs", "logical_job_id", "ALTER TABLE scrape_jobs ADD COLUMN logical_job_id VARCHAR(64)"),
     ("scrape_jobs", "parent_job_id", "ALTER TABLE scrape_jobs ADD COLUMN parent_job_id VARCHAR(64)"),

--- a/models.py
+++ b/models.py
@@ -139,12 +139,18 @@ class ProductSnapshot(Base):
 
 class DescriptionTemplate(Base):
     __tablename__ = "description_templates"
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="uq_description_templates_user_name"),
+    )
 
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False, unique=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    name = Column(String, nullable=False)
     content = Column(Text, nullable=False)
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
+
+    user = relationship("User")
 
 
 class PricingRule(Base):

--- a/routes/products.py
+++ b/routes/products.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from flask import Blueprint, render_template, request, redirect, url_for, session
 from flask_login import login_required, current_user
+from sqlalchemy import or_
 from werkzeug.utils import secure_filename
 
 from database import SessionLocal
@@ -157,7 +158,17 @@ def _build_image_snapshot(product, base_snapshot, image_urls):
 def _render_product_detail(session_db, product, snapshot, images, *, error=None, status_code=200):
     from services.translator import compute_source_hash
 
-    templates = session_db.query(DescriptionTemplate).order_by(DescriptionTemplate.name).all()
+    templates = (
+        session_db.query(DescriptionTemplate)
+        .filter(
+            or_(
+                DescriptionTemplate.user_id == current_user.id,
+                DescriptionTemplate.user_id.is_(None),
+            )
+        )
+        .order_by(DescriptionTemplate.name)
+        .all()
+    )
     all_shops = session_db.query(Shop).filter_by(user_id=current_user.id).all()
     current_shop_id = session.get('current_shop_id')
     variants = session_db.query(Variant).filter_by(product_id=product.id).order_by(Variant.position).all()

--- a/routes/shops.py
+++ b/routes/shops.py
@@ -6,6 +6,7 @@ import uuid
 
 from flask import Blueprint, render_template, request, redirect, url_for, session
 from flask_login import login_required, current_user
+from sqlalchemy import or_
 from werkzeug.utils import secure_filename
 
 from database import SessionLocal
@@ -271,17 +272,29 @@ def manage_templates():
     session_db = SessionLocal()
     try:
         if request.method == "POST":
-            name = request.form.get("name")
+            name = (request.form.get("name") or "").strip()
             content = normalize_rich_text(request.form.get("content"))
             if name and content:
-                new_template = DescriptionTemplate(name=name, content=content)
+                new_template = DescriptionTemplate(
+                    user_id=current_user.id,
+                    name=name,
+                    content=content,
+                )
                 session_db.add(new_template)
                 session_db.commit()
             return redirect(url_for('shops.manage_templates'))
 
-        templates = session_db.query(DescriptionTemplate).order_by(DescriptionTemplate.id).all()
-        # Only show user's shops for context if needed, but template is global for now? 
-        # Requirement was Shop/Product isolation. Let's filter Shop list in dropdown.
+        templates = (
+            session_db.query(DescriptionTemplate)
+            .filter(
+                or_(
+                    DescriptionTemplate.user_id == current_user.id,
+                    DescriptionTemplate.user_id.is_(None),
+                )
+            )
+            .order_by(DescriptionTemplate.id)
+            .all()
+        )
         all_shops = session_db.query(Shop).filter_by(user_id=current_user.id).all()
         current_shop_id = session.get('current_shop_id')
 
@@ -303,7 +316,11 @@ def manage_templates():
 def delete_template(template_id):
     session_db = SessionLocal()
     try:
-        template = session_db.query(DescriptionTemplate).filter_by(id=template_id).one_or_none()
+        template = (
+            session_db.query(DescriptionTemplate)
+            .filter_by(id=template_id, user_id=current_user.id)
+            .one_or_none()
+        )
         if template:
             session_db.delete(template)
             session_db.commit()

--- a/services/rich_text_maintenance.py
+++ b/services/rich_text_maintenance.py
@@ -49,6 +49,12 @@ def run_rich_text_maintenance(*, apply: bool = False, user_id: int | None = None
             product_query = product_query.filter(Product.user_id == user_id)
             pricelist_query = pricelist_query.filter(PriceList.user_id == user_id)
             snapshot_query = snapshot_query.join(Product, Product.id == ProductSnapshot.product_id).filter(Product.user_id == user_id)
+            description_template_query = (
+                session_db.query(DescriptionTemplate)
+                .filter(DescriptionTemplate.user_id == user_id)
+            )
+        else:
+            description_template_query = session_db.query(DescriptionTemplate)
 
         sections: dict[str, dict[str, int]] = {}
         sections["products"] = _process_records(
@@ -61,14 +67,11 @@ def run_rich_text_maintenance(*, apply: bool = False, user_id: int | None = None
             ("notes",),
             _normalize_optional_rich_text,
         )
-        if user_id is None:
-            sections["description_templates"] = _process_records(
-                session_db.query(DescriptionTemplate).order_by(DescriptionTemplate.id),
-                ("content",),
-                _normalize_optional_rich_text,
-            )
-        else:
-            warnings.append("description_templates_skipped_for_user_scope")
+        sections["description_templates"] = _process_records(
+            description_template_query.order_by(DescriptionTemplate.id),
+            ("content",),
+            _normalize_optional_rich_text,
+        )
 
         if include_snapshots:
             sections["product_snapshots"] = _process_records(

--- a/templates/manage_templates.html
+++ b/templates/manage_templates.html
@@ -25,14 +25,23 @@
                 {% for t in templates %}
                 <tr>
                     <td>{{ t.id }}</td>
-                    <td>{{ t.name }}</td>
+                    <td>
+                        {{ t.name }}
+                        {% if t.user_id is none %}
+                        <span class="text-muted" style="font-size: 0.85em;">(共有 / 旧データ)</span>
+                        {% endif %}
+                    </td>
                     <td class="hide-mobile">{{ (t.content | striptags)[:50] if t.content else '' }}...</td>
                     <td>
+                        {% if t.user_id is none %}
+                        <span class="text-muted" style="font-size: 0.85em;">削除不可</span>
+                        {% else %}
                         <form method="POST" action="{{ url_for('delete_template', template_id=t.id) }}"
                             style="display:inline;">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                             <button type="submit" onclick="return confirm('本当に削除しますか？');" class="btn-danger">削除</button>
                         </form>
+                        {% endif %}
                     </td>
                 </tr>
                 {% endfor %}

--- a/tests/test_cli_rich_text_maintenance.py
+++ b/tests/test_cli_rich_text_maintenance.py
@@ -49,6 +49,7 @@ def _create_dirty_records(db_session, suffix: str):
 def test_rich_text_maintenance_cli_dry_run_reports_changes_without_applying(app, db_session):
     user, product, snapshot, pricelist = _create_dirty_records(db_session, "dry-run")
     template = DescriptionTemplate(
+        user_id=user.id,
         name="Dirty Template Dry Run",
         content="<p>Template</p><script>bad()</script>",
     )
@@ -78,11 +79,18 @@ def test_rich_text_maintenance_cli_dry_run_reports_changes_without_applying(app,
 def test_rich_text_maintenance_cli_apply_scopes_to_user_records(app, db_session):
     user_one, product_one, snapshot_one, pricelist_one = _create_dirty_records(db_session, "user-one")
     user_two, product_two, snapshot_two, pricelist_two = _create_dirty_records(db_session, "user-two")
-    template = DescriptionTemplate(
-        name="Dirty Template Scoped",
+    template_one = DescriptionTemplate(
+        user_id=user_one.id,
+        name="Dirty Template Scoped One",
         content="<p>Template</p><script>bad()</script>",
     )
-    db_session.add(template)
+    template_two = DescriptionTemplate(
+        user_id=user_two.id,
+        name="Dirty Template Scoped Two",
+        content="<p>Template</p><script>bad()</script>",
+    )
+    db_session.add(template_one)
+    db_session.add(template_two)
     db_session.commit()
 
     runner = app.test_cli_runner()
@@ -98,9 +106,10 @@ def test_rich_text_maintenance_cli_apply_scopes_to_user_records(app, db_session)
     assert result.exit_code == 0
     payload = _load_last_json_line(result.output)
     assert payload["mode"] == "apply"
-    assert payload["warnings"] == ["description_templates_skipped_for_user_scope"]
+    assert payload["warnings"] == []
     assert payload["sections"]["products"]["changed"] == 1
     assert payload["sections"]["price_lists"]["changed"] == 1
+    assert payload["sections"]["description_templates"]["changed"] == 1
     assert payload["sections"]["product_snapshots"]["changed"] == 1
 
     db_session.refresh(product_one)
@@ -109,7 +118,8 @@ def test_rich_text_maintenance_cli_apply_scopes_to_user_records(app, db_session)
     db_session.refresh(product_two)
     db_session.refresh(snapshot_two)
     db_session.refresh(pricelist_two)
-    db_session.refresh(template)
+    db_session.refresh(template_one)
+    db_session.refresh(template_two)
 
     assert product_one.custom_description == normalize_rich_text("<p>Hello</p><span>World</span>")
     assert product_one.custom_description_en == normalize_rich_text("Line one\nLine two")
@@ -119,4 +129,5 @@ def test_rich_text_maintenance_cli_apply_scopes_to_user_records(app, db_session)
     assert product_two.custom_description == "<p>Hello</p><span>World</span>"
     assert snapshot_two.description == "<p>Snap</p><script>alert(1)</script>"
     assert pricelist_two.notes == "<p>Note</p><span>Extra</span>"
-    assert template.content == "<p>Template</p><script>bad()</script>"
+    assert template_one.content == normalize_rich_text("<p>Template</p><script>bad()</script>")
+    assert template_two.content == "<p>Template</p><script>bad()</script>"

--- a/tests/test_database_bootstrap.py
+++ b/tests/test_database_bootstrap.py
@@ -162,6 +162,37 @@ def test_apply_additive_startup_migrations_backfills_scrape_job_columns():
     assert "tracker_dismissed_at" in columns
 
 
+def test_apply_additive_startup_migrations_adds_description_template_user_id():
+    smoke_db = Path(f"test_db_additive_description_templates_{uuid.uuid4().hex}.sqlite")
+    smoke_engine = database.create_app_engine(f"sqlite:///{smoke_db.as_posix()}")
+
+    try:
+        with smoke_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE description_templates (
+                        id INTEGER PRIMARY KEY,
+                        name VARCHAR NOT NULL,
+                        content TEXT NOT NULL,
+                        created_at TIMESTAMP,
+                        updated_at TIMESTAMP
+                    )
+                    """
+                )
+            )
+
+        with smoke_engine.begin() as connection:
+            results = database.apply_additive_startup_migrations(bind=connection)
+        columns = {column["name"] for column in inspect(smoke_engine).get_columns("description_templates")}
+    finally:
+        smoke_engine.dispose()
+        smoke_db.unlink(missing_ok=True)
+
+    assert "description_templates.user_id" in results["applied"]
+    assert "user_id" in columns
+
+
 def test_apply_additive_startup_migrations_avoids_missing_column_probe_queries(monkeypatch):
     class FakeInspector:
         def __init__(self, table_columns):
@@ -279,7 +310,7 @@ def test_run_alembic_upgrade_for_database_url_backfills_tracker_dismissed_at_fro
     assert "ix_scrape_jobs_tracker_dismissed_at" in indexes
     assert "selector_repair_candidates" in table_names
     assert "selector_active_rule_sets" in table_names
-    assert version_num == "20260411_0005"
+    assert version_num == "20260422_0006"
 
 
 def test_inspect_additive_schema_drift_reports_missing_scrape_job_columns():

--- a/tests/test_e2e_routes.py
+++ b/tests/test_e2e_routes.py
@@ -553,10 +553,61 @@ class TestShopsRoutes:
         self._login_user(client, db_session, 'templatestest')
         response = client.get('/templates')
         assert response.status_code == 200
+
+    def test_templates_page_shows_only_current_users_templates(self, client, db_session):
+        """Authenticated users should not see other users' templates."""
+        owner = self._login_user(client, db_session, 'templateownerscope')
+        other_user = User(username='templateotherscope')
+        other_user.set_password('testpassword')
+        db_session.add(other_user)
+        db_session.commit()
+
+        db_session.add(
+            DescriptionTemplate(
+                user_id=owner.id,
+                name='Owner Template',
+                content='Owner content',
+            )
+        )
+        db_session.add(
+            DescriptionTemplate(
+                user_id=other_user.id,
+                name='Other Template',
+                content='Other content',
+            )
+        )
+        db_session.commit()
+
+        response = client.get('/templates')
+
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Owner Template' in html
+        assert 'Other Template' not in html
+
+    def test_templates_page_keeps_legacy_shared_templates_visible(self, client, db_session):
+        """Legacy templates without ownership should stay visible during migration."""
+        self._login_user(client, db_session, 'templatelegacyvisible')
+        db_session.add(
+            DescriptionTemplate(
+                user_id=None,
+                name='Legacy Shared Template',
+                content='Legacy content',
+            )
+        )
+        db_session.commit()
+
+        response = client.get('/templates')
+
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Legacy Shared Template' in html
+        assert '共有 / 旧データ' in html
+        assert '削除不可' in html
     
     def test_create_template(self, client, db_session):
         """Test creating a description template"""
-        self._login_user(client, db_session, 'createtemplatetest')
+        user = self._login_user(client, db_session, 'createtemplatetest')
         
         response = client.post('/templates', data={
             'name': 'Test Template',
@@ -566,13 +617,50 @@ class TestShopsRoutes:
         assert response.status_code == 200
         
         # Verify template was created
-        template = db_session.query(DescriptionTemplate).filter_by(name='Test Template').first()
+        template = db_session.query(DescriptionTemplate).filter_by(
+            user_id=user.id,
+            name='Test Template',
+        ).first()
         assert template is not None
         assert template.content == 'This is test template content'
+        assert template.user_id == user.id
+
+    def test_create_template_allows_same_name_for_different_users(self, client, db_session):
+        """Different users can keep templates with the same display name."""
+        user_one = self._login_user(client, db_session, 'createtemplatesameone')
+        response_one = client.post('/templates', data={
+            'name': 'Shared Template Name',
+            'content': 'Owner one content',
+        }, follow_redirects=True)
+        assert response_one.status_code == 200
+
+        user_two = User(username='createtemplatesametwo')
+        user_two.set_password('testpassword')
+        db_session.add(user_two)
+        db_session.commit()
+
+        client.get('/logout', follow_redirects=True)
+        client.post('/login', data={
+            'username': user_two.username,
+            'password': 'testpassword',
+        }, follow_redirects=True)
+        response_two = client.post('/templates', data={
+            'name': 'Shared Template Name',
+            'content': 'Owner two content',
+        }, follow_redirects=True)
+
+        assert response_two.status_code == 200
+        templates = (
+            db_session.query(DescriptionTemplate)
+            .filter(DescriptionTemplate.name == 'Shared Template Name')
+            .order_by(DescriptionTemplate.user_id.asc())
+            .all()
+        )
+        assert [template.user_id for template in templates] == [user_one.id, user_two.id]
 
     def test_create_template_sanitizes_rich_text(self, client, db_session):
         """Test template content is normalized to the shared safe rich-text subset"""
-        self._login_user(client, db_session, 'createtemplatesanitizetest')
+        user = self._login_user(client, db_session, 'createtemplatesanitizetest')
 
         response = client.post('/templates', data={
             'name': 'Sanitized Template',
@@ -581,16 +669,19 @@ class TestShopsRoutes:
 
         assert response.status_code == 200
 
-        template = db_session.query(DescriptionTemplate).filter_by(name='Sanitized Template').first()
+        template = db_session.query(DescriptionTemplate).filter_by(
+            user_id=user.id,
+            name='Sanitized Template',
+        ).first()
         assert template is not None
         assert '<script' not in template.content.lower()
         assert 'Hello' in template.content
     
     def test_delete_template(self, client, db_session):
         """Test deleting a template"""
-        self._login_user(client, db_session, 'deletetemplatetest')
+        user = self._login_user(client, db_session, 'deletetemplatetest')
         
-        template = DescriptionTemplate(name='Template to Delete', content='Content')
+        template = DescriptionTemplate(user_id=user.id, name='Template to Delete', content='Content')
         db_session.add(template)
         db_session.commit()
         template_id = template.id
@@ -601,6 +692,47 @@ class TestShopsRoutes:
         # Verify template was deleted
         deleted_template = db_session.query(DescriptionTemplate).filter_by(id=template_id).first()
         assert deleted_template is None
+
+    def test_delete_template_does_not_remove_other_users_template(self, client, db_session):
+        """Users must not be able to delete templates they do not own."""
+        self._login_user(client, db_session, 'templatedeleteownercheck')
+
+        other_user = User(username='templatedeleteother')
+        other_user.set_password('testpassword')
+        db_session.add(other_user)
+        db_session.commit()
+
+        template = DescriptionTemplate(
+            user_id=other_user.id,
+            name='Other User Template',
+            content='Content',
+        )
+        db_session.add(template)
+        db_session.commit()
+        template_id = template.id
+
+        response = client.post(f'/templates/{template_id}/delete', follow_redirects=True)
+
+        assert response.status_code == 200
+        assert db_session.query(DescriptionTemplate).filter_by(id=template_id).first() is not None
+
+    def test_delete_template_does_not_remove_legacy_shared_template(self, client, db_session):
+        """Legacy shared templates remain visible but are not deletable by scoped users."""
+        self._login_user(client, db_session, 'templatedeletelegacycheck')
+
+        template = DescriptionTemplate(
+            user_id=None,
+            name='Legacy Shared Template Delete',
+            content='Content',
+        )
+        db_session.add(template)
+        db_session.commit()
+        template_id = template.id
+
+        response = client.post(f'/templates/{template_id}/delete', follow_redirects=True)
+
+        assert response.status_code == 200
+        assert db_session.query(DescriptionTemplate).filter_by(id=template_id).first() is not None
 
 
 class TestPriceListRoutes:
@@ -1234,6 +1366,55 @@ class TestProductRoutes:
         assert 'タイトル翻訳' in html
         assert '自動翻訳' in html
         assert 'URLから追加' in html
+
+    def test_product_detail_shows_only_current_users_templates(self, client, db_session):
+        """Product edit should not expose other users' description templates."""
+        user, product, _ = self._setup_user_with_product(client, db_session, 'productdetailtemplatescope')
+        other_user = User(username='productdetailtemplateother')
+        other_user.set_password('testpassword')
+        db_session.add(other_user)
+        db_session.commit()
+
+        db_session.add(
+            DescriptionTemplate(
+                user_id=user.id,
+                name='Owner Product Template',
+                content='Owner content',
+            )
+        )
+        db_session.add(
+            DescriptionTemplate(
+                user_id=other_user.id,
+                name='Other Product Template',
+                content='Other content',
+            )
+        )
+        db_session.commit()
+
+        response = client.get(f'/product/{product.id}')
+
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Owner Product Template' in html
+        assert 'Other Product Template' not in html
+
+    def test_product_detail_keeps_legacy_shared_templates_visible(self, client, db_session):
+        """Legacy shared templates should remain available in the editor during rollout."""
+        user, product, _ = self._setup_user_with_product(client, db_session, 'productdetailtemplatelegacy')
+        db_session.add(
+            DescriptionTemplate(
+                user_id=None,
+                name='Legacy Product Template',
+                content='Legacy product content',
+            )
+        )
+        db_session.commit()
+
+        response = client.get(f'/product/{product.id}')
+
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Legacy Product Template' in html
     
     def test_product_detail_403_for_other_user(self, client, db_session):
         """Test product detail returns 404 for products owned by other user"""


### PR DESCRIPTION
## Summary
- scope new description templates to the creating user and hide other users' private templates
- keep legacy shared templates (`user_id IS NULL`) visible during rollout as read-only compatibility data
- add migration/test coverage for the new user scope and harden the translation-suggestions migration for sparse legacy databases

## Testing
- py -3 -m pytest tests/test_e2e_routes.py tests/test_cli_rich_text_maintenance.py tests/test_database_bootstrap.py tests/test_worker_entrypoint.py tests/test_worker_runtime.py -q
