### PR TITLE
[codex] fix scrape selected registration persistence

### DIFF
--- a/routes/scrape.py
+++ b/routes/scrape.py
@@ -282,20 +282,37 @@ def register_selected():
     if not selected_items:
         return jsonify({"error": "No valid items selected"}), 400
 
-    new_count, updated_count = save_scraped_items_to_db(
-        selected_items,
-        user_id=current_user.id,
-        site=result.get("site", "mercari"),
-        shop_id=result.get("shop_id"),
-        manual_selection=True,
-    )
+    try:
+        save_summary = save_scraped_items_to_db(
+            selected_items,
+            user_id=current_user.id,
+            site=result.get("site", "mercari"),
+            shop_id=result.get("shop_id"),
+            manual_selection=True,
+            return_summary=True,
+            raise_on_error=True,
+        )
+    except Exception:
+        return jsonify({"error": "選択商品の保存に失敗しました。時間をおいて再度お試しください。"}), 500
+
+    registered_count = int(save_summary.get("processed_count") or 0)
+    if registered_count <= 0:
+        return jsonify(
+            {
+                "error": "選択した商品は保存できませんでした。商品URL、タイトル、取得状態を確認してください。",
+                "registered_count": 0,
+                "rejected_count": save_summary.get("rejected_count", len(selected_items)),
+            }
+        ), 422
 
     return jsonify(
         {
             "ok": True,
-            "registered_count": len(selected_items),
-            "new_count": new_count,
-            "updated_count": updated_count,
+            "registered_count": registered_count,
+            "selected_count": len(selected_items),
+            "new_count": save_summary.get("new_count", 0),
+            "updated_count": save_summary.get("updated_count", 0),
+            "rejected_count": save_summary.get("rejected_count", 0),
         }
     )
 

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -2,6 +2,7 @@
 Product service for database operations related to scraped items.
 """
 import hashlib
+import logging
 from flask import has_request_context, session
 
 from database import SessionLocal
@@ -10,9 +11,117 @@ from services.pricing_service import update_product_selling_price
 from services.scrape_result_policy import (
     evaluate_persistence,
     normalize_item_for_persistence,
+    normalize_price_for_persistence,
 )
 from time_utils import utc_now
 from utils import normalize_url
+
+
+logger = logging.getLogger(__name__)
+
+
+def _empty_save_summary(input_count: int = 0):
+    return {
+        "input_count": input_count,
+        "processed_count": 0,
+        "new_count": 0,
+        "updated_count": 0,
+        "rejected_count": 0,
+    }
+
+
+def _normalize_text(value) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_image_urls(value) -> list[str]:
+    if isinstance(value, str):
+        candidates = value.replace("\r", "\n").replace("|", "\n").split("\n")
+    elif isinstance(value, (list, tuple, set)):
+        candidates = value
+    else:
+        candidates = []
+
+    normalized_urls = []
+    seen_urls = set()
+    for candidate in candidates:
+        url = _normalize_text(candidate)
+        if not url:
+            continue
+        if url in seen_urls:
+            continue
+        normalized_urls.append(url)
+        seen_urls.add(url)
+    return normalized_urls
+
+
+def _normalize_non_negative_int(value, default: int = 0) -> int:
+    normalized = normalize_price_for_persistence(value)
+    if normalized is None or normalized < 0:
+        return default
+    return normalized
+
+
+def _default_inventory_for_status(status: str) -> int:
+    return 1 if status == "on_sale" else 0
+
+
+def _normalize_scraped_variants(raw_variants, *, fallback_price, status: str):
+    if not isinstance(raw_variants, (list, tuple)):
+        return []
+
+    normalized_variants = []
+    for index, variant in enumerate(raw_variants, 1):
+        if not isinstance(variant, dict):
+            continue
+
+        variant_price = normalize_price_for_persistence(variant.get("price"))
+        if variant_price is None:
+            variant_price = fallback_price
+
+        inventory_default = _default_inventory_for_status(status)
+        inventory_qty = _normalize_non_negative_int(variant.get("inventory_qty"), inventory_default)
+        if status in {"sold", "deleted"}:
+            inventory_qty = 0
+
+        normalized_variants.append(
+            {
+                "option1_name": _normalize_text(variant.get("option1_name")),
+                "option1_value": _normalize_text(variant.get("option1_value")) or f"Option {index}",
+                "option2_name": _normalize_text(variant.get("option2_name")),
+                "option2_value": _normalize_text(variant.get("option2_value")) or None,
+                "option3_name": _normalize_text(variant.get("option3_name")),
+                "option3_value": _normalize_text(variant.get("option3_value")) or None,
+                "price": variant_price,
+                "inventory_qty": inventory_qty,
+            }
+        )
+    return normalized_variants
+
+
+def _find_product_for_source(session_db, *, url: str, user_id: int, shop_id):
+    base_query = session_db.query(Product).filter_by(source_url=url, user_id=user_id)
+
+    if shop_id is None:
+        return base_query.filter(Product.shop_id.is_(None)).order_by(Product.id.asc()).first()
+
+    scoped_product = (
+        base_query
+        .filter(Product.shop_id == shop_id)
+        .order_by(Product.id.asc())
+        .first()
+    )
+    if scoped_product is not None:
+        return scoped_product
+
+    return (
+        base_query
+        .filter(Product.shop_id.is_(None))
+        .order_by(Product.id.asc())
+        .first()
+    )
 
 
 def save_scraped_items_to_db(
@@ -21,17 +130,23 @@ def save_scraped_items_to_db(
     site: str = "mercari",
     shop_id=None,
     manual_selection: bool = False,
+    return_summary: bool = False,
+    raise_on_error: bool = False,
 ):
     """
     mercari_db.scrape_search_result() が返した items(list[dict]) を
     Product / ProductSnapshot に保存する。
     """
+    input_count = len(items or [])
     if not items:
-        return 0, 0
+        summary = _empty_save_summary(input_count)
+        return summary if return_summary else (0, 0)
 
     session_db = SessionLocal()
     new_count = 0
     updated_count = 0
+    processed_count = 0
+    rejected_count = 0
     now = utc_now()
     repricing_product_ids = set()
 
@@ -43,20 +158,26 @@ def save_scraped_items_to_db(
         for item in items:
             raw_url = item.get("url", "")
             if not raw_url:
+                rejected_count += 1
                 continue
 
             url = normalize_url(raw_url)
             normalized_item = normalize_item_for_persistence(item, manual_selection=manual_selection)
             scrape_meta = item.get("_scrape_meta") or {}
 
-            title = normalized_item.get("title") or ""
+            title = _normalize_text(normalized_item.get("title"))
             price = normalized_item.get("price")
             status = normalized_item.get("status") or ""
-            description = normalized_item.get("description") or ""
-            image_urls = normalized_item.get("image_urls") or []
+            description = _normalize_text(normalized_item.get("description"))
+            image_urls = _normalize_image_urls(normalized_item.get("image_urls"))
             image_urls_str = "|".join(image_urls)
 
-            product = session_db.query(Product).filter_by(source_url=url, user_id=user_id).one_or_none()
+            product = _find_product_for_source(
+                session_db,
+                url=url,
+                user_id=user_id,
+                shop_id=resolved_shop_id,
+            )
             persistence_action = evaluate_persistence(
                 site,
                 normalized_item,
@@ -65,10 +186,12 @@ def save_scraped_items_to_db(
                 manual_selection=manual_selection,
             )
             if persistence_action == "reject":
+                rejected_count += 1
                 continue
 
             if product is None:
                 if persistence_action != "allow_full":
+                    rejected_count += 1
                     continue
 
                 sku_hash = hashlib.md5(url.encode('utf-8')).hexdigest()[:10].upper()
@@ -88,26 +211,38 @@ def save_scraped_items_to_db(
                 session_db.add(product)
                 session_db.flush()
                 new_count += 1
+                processed_count += 1
 
-                scraped_variants = normalized_item.get("variants")
+                scraped_variants = _normalize_scraped_variants(
+                    normalized_item.get("variants"),
+                    fallback_price=price,
+                    status=status,
+                )
                 if scraped_variants:
-                    product.option1_name = normalized_item.get("option1_name", "Variation")
-                    product.option2_name = normalized_item.get("option2_name")
-                    product.option3_name = normalized_item.get("option3_name")
+                    product.option1_name = (
+                        _normalize_text(normalized_item.get("option1_name"))
+                        or scraped_variants[0].get("option1_name")
+                        or "Variation"
+                    )
+                    product.option2_name = (
+                        _normalize_text(normalized_item.get("option2_name"))
+                        or scraped_variants[0].get("option2_name")
+                    )
+                    product.option3_name = (
+                        _normalize_text(normalized_item.get("option3_name"))
+                        or scraped_variants[0].get("option3_name")
+                    )
 
                     for i, v_data in enumerate(scraped_variants, 1):
-                        inventory_qty = v_data.get("inventory_qty", 1)
-                        if status in {"sold", "deleted"}:
-                            inventory_qty = 0
                         new_variant = Variant(
                             product_id=product.id,
-                            option1_value=v_data.get("option1_value", f"Option {i}"),
+                            option1_value=v_data.get("option1_value") or f"Option {i}",
                             option2_value=v_data.get("option2_value"),
                             option3_value=v_data.get("option3_value"),
                             sku=f"{generated_sku}-{i}",
                             price=v_data.get("price", price),
                             taxable=False,
-                            inventory_qty=inventory_qty,
+                            inventory_qty=v_data.get("inventory_qty", _default_inventory_for_status(status)),
                             position=i,
                         )
                         session_db.add(new_variant)
@@ -118,7 +253,7 @@ def save_scraped_items_to_db(
                         sku=generated_sku,
                         price=price,
                         taxable=False,
-                        inventory_qty=0 if status in {"sold", "deleted"} else 1,
+                        inventory_qty=_default_inventory_for_status(status),
                         position=1,
                     )
                     session_db.add(default_variant)
@@ -137,6 +272,7 @@ def save_scraped_items_to_db(
                             existing_variant.inventory_qty = 0
                     if status_changed:
                         updated_count += 1
+                    processed_count += 1
                     continue
 
                 title_changed = bool(title.strip()) and product.last_title != title
@@ -162,8 +298,9 @@ def save_scraped_items_to_db(
                         existing_variant.price = price
                     if status in {"sold", "deleted"}:
                         existing_variant.inventory_qty = 0
-                    elif existing_variant.option1_value == "Default Title":
+                    elif status == "on_sale" and existing_variant.option1_value == "Default Title":
                         existing_variant.inventory_qty = existing_variant.inventory_qty or 1
+                processed_count += 1
 
             snapshot = ProductSnapshot(
                 product_id=product.id,
@@ -184,10 +321,20 @@ def save_scraped_items_to_db(
         if repricing_product_ids:
             session_db.commit()
 
-        return new_count, updated_count
-    except Exception as e:
+        summary = {
+            "input_count": input_count,
+            "processed_count": processed_count,
+            "new_count": new_count,
+            "updated_count": updated_count,
+            "rejected_count": rejected_count,
+        }
+        return summary if return_summary else (new_count, updated_count)
+    except Exception:
         session_db.rollback()
-        print("DB 保存エラー:", e)
-        return 0, 0
+        logger.exception("DB 保存エラー")
+        if raise_on_error:
+            raise
+        summary = _empty_save_summary(input_count)
+        return summary if return_summary else (0, 0)
     finally:
         session_db.close()

--- a/services/scrape_result_policy.py
+++ b/services/scrape_result_policy.py
@@ -4,7 +4,32 @@ Persistence policy for scraper outputs.
 Fail closed on uncertain active prices so noisy pages cannot overwrite good
 product state.
 """
+import re
 from typing import Optional
+
+
+def normalize_price_for_persistence(value) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    match = re.search(r"[-+]?\d[\d,]*", text)
+    if not match:
+        return None
+
+    try:
+        return int(match.group(0).replace(",", ""))
+    except ValueError:
+        return None
 
 
 def normalize_status_for_persistence(status: Optional[str]) -> str:
@@ -22,16 +47,13 @@ def _can_promote_unknown_status_for_manual_selection(item: Optional[dict]) -> bo
     if not title:
         return False
 
-    price = candidate.get("price")
-    try:
-        numeric_price = int(price) if price is not None else None
-    except (TypeError, ValueError):
-        numeric_price = None
+    numeric_price = normalize_price_for_persistence(candidate.get("price"))
     return numeric_price is not None and numeric_price > 0
 
 
 def normalize_item_for_persistence(item: Optional[dict], *, manual_selection: bool = False) -> dict:
     normalized = dict(item or {})
+    normalized["price"] = normalize_price_for_persistence(normalized.get("price"))
     normalized["status"] = normalize_status_for_persistence(normalized.get("status"))
     if manual_selection and normalized["status"] == "unknown" and _can_promote_unknown_status_for_manual_selection(normalized):
         normalized["status"] = "on_sale"
@@ -52,16 +74,12 @@ def evaluate_persistence(
     title = str(normalized.get("title") or "").strip()
     confidence = str((meta or {}).get("confidence") or "high").lower()
 
-    price = normalized.get("price")
-    try:
-        numeric_price = int(price) if price is not None else None
-    except (TypeError, ValueError):
-        numeric_price = None
+    numeric_price = normalize_price_for_persistence(normalized.get("price"))
 
     if status in {"blocked", "error"}:
         return "reject"
     if status == "unknown":
-        return "allow_full" if manual_selection and numeric_price is not None and numeric_price > 0 and title else "reject"
+        return "allow_full" if manual_selection and title else "reject"
 
     if status == "deleted":
         return "allow_status_only" if existing_product is not None else "reject"
@@ -70,7 +88,7 @@ def evaluate_persistence(
         if existing_product is not None and (numeric_price is None or numeric_price <= 0):
             return "allow_status_only"
         if numeric_price is None or numeric_price <= 0:
-            return "reject"
+            return "allow_full" if manual_selection and title else "reject"
         if confidence == "low":
             return "allow_status_only" if existing_product is not None else "reject"
         if not title:
@@ -79,7 +97,7 @@ def evaluate_persistence(
 
     if status == "on_sale":
         if numeric_price is None or numeric_price <= 0:
-            return "reject"
+            return "allow_full" if manual_selection and title else "reject"
         if confidence == "low":
             return "reject"
         if not title:

--- a/tests/test_product_service.py
+++ b/tests/test_product_service.py
@@ -251,3 +251,95 @@ def test_save_scraped_items_does_not_persist_scrape_meta_fields(client, db_sessi
     assert '_scrape_meta' not in product.__dict__
     assert '_scrape_meta' not in snapshot.__dict__
 
+
+def test_save_scraped_items_normalizes_string_prices_and_variant_quantities(client, db_session):
+    user = _create_user(db_session, 'product_service_price_string_user')
+
+    items = [
+        {
+            'url': 'https://store.shopping.yahoo.co.jp/example/item-string-price.html?tracking=1',
+            'title': 'String Price Item',
+            'price': '¥1,980',
+            'status': 'active',
+            'description': 'stored from yahoo',
+            'image_urls': ['https://img.example.com/string-price.jpg'],
+            'variants': [
+                {
+                    'option1_name': 'Color',
+                    'option1_value': 'Black',
+                    'price': '2,100',
+                    'inventory_qty': '3',
+                }
+            ],
+        }
+    ]
+
+    new_count, updated_count = save_scraped_items_to_db(
+        items,
+        user_id=user.id,
+        site='yahoo',
+    )
+
+    assert new_count == 1
+    assert updated_count == 0
+
+    db_session.expire_all()
+    product = db_session.query(Product).filter_by(user_id=user.id).one()
+    variant = db_session.query(Variant).filter_by(product_id=product.id).one()
+
+    assert product.source_url == 'https://store.shopping.yahoo.co.jp/example/item-string-price.html'
+    assert product.last_price == 1980
+    assert product.last_status == 'on_sale'
+    assert variant.price == 2100
+    assert variant.inventory_qty == 3
+
+
+def test_save_scraped_items_keeps_same_source_url_isolated_by_shop(client, db_session):
+    user = _create_user(db_session, 'product_service_shop_scope_user')
+    source_shop = Shop(name='Source Shop', user_id=user.id)
+    target_shop = Shop(name='Target Shop', user_id=user.id)
+    db_session.add_all([source_shop, target_shop])
+    db_session.commit()
+
+    existing = Product(
+        user_id=user.id,
+        site='mercari',
+        shop_id=source_shop.id,
+        source_url='https://jp.mercari.com/item/m-shop-scope',
+        last_title='Existing Shop Item',
+        last_price=1000,
+        last_status='on_sale',
+        created_at=utc_now(),
+        updated_at=utc_now(),
+    )
+    db_session.add(existing)
+    db_session.commit()
+
+    items = [
+        {
+            'url': 'https://jp.mercari.com/item/m-shop-scope?utm=preview',
+            'title': 'Target Shop Item',
+            'price': 1600,
+            'status': 'on_sale',
+            'description': 'same source in another shop',
+            'image_urls': ['https://img.example.com/shop-scope.jpg'],
+        }
+    ]
+
+    new_count, updated_count = save_scraped_items_to_db(
+        items,
+        user_id=user.id,
+        site='mercari',
+        shop_id=target_shop.id,
+    )
+
+    assert new_count == 1
+    assert updated_count == 0
+
+    db_session.expire_all()
+    products = db_session.query(Product).filter_by(user_id=user.id).order_by(Product.shop_id.asc()).all()
+    assert len(products) == 2
+    assert {product.shop_id for product in products} == {source_shop.id, target_shop.id}
+    assert db_session.query(Product).filter_by(shop_id=source_shop.id).one().last_title == 'Existing Shop Item'
+    assert db_session.query(Product).filter_by(shop_id=target_shop.id).one().last_title == 'Target Shop Item'
+

--- a/tests/test_scrape_preview_flow.py
+++ b/tests/test_scrape_preview_flow.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from models import Product, ScrapeJob, Shop, User
+from models import Product, ScrapeJob, Shop, User, Variant
 from time_utils import utc_now
 
 
@@ -325,6 +325,91 @@ def test_register_selected_allows_unknown_status_when_user_explicitly_selected(c
     product = db_session.query(Product).filter_by(user_id=user.id).one()
     assert product.last_title == 'Preview Unknown Item'
     assert product.last_status == 'on_sale'
+
+
+def test_register_selected_saves_explicitly_selected_item_without_price(client, db_session, monkeypatch):
+    user = login_user(client, db_session, 'register_selected_no_price_user')
+    fake_queue = FakeQueue()
+    fake_queue.jobs['job-1'] = {
+        'job_id': 'job-1',
+        'status': 'completed',
+        'result': {
+            'items': [
+                {
+                    'url': 'https://store.shopping.yahoo.co.jp/example/no-price.html',
+                    'title': 'Preview No Price Item',
+                    'price': None,
+                    'status': 'unknown',
+                    'description': 'preview no price',
+                    'image_urls': ['https://img.example.com/no-price.jpg'],
+                },
+            ],
+            'site': 'yahoo',
+        },
+        'error': None,
+        'elapsed_seconds': 0.1,
+        'queue_position': None,
+        'user_id': user.id,
+    }
+
+    monkeypatch.setattr('routes.scrape.get_queue', lambda: fake_queue)
+
+    response = client.post('/scrape/register-selected', json={
+        'job_id': 'job-1',
+        'selected_indices': [0]
+    })
+
+    assert response.status_code == 200
+    assert response.json['ok'] is True
+    assert response.json['registered_count'] == 1
+    assert response.json['new_count'] == 1
+
+    db_session.expire_all()
+    product = db_session.query(Product).filter_by(user_id=user.id).one()
+    variant = db_session.query(Variant).filter_by(product_id=product.id).one()
+    assert product.last_title == 'Preview No Price Item'
+    assert product.last_price is None
+    assert product.last_status == 'unknown'
+    assert variant.price is None
+    assert variant.inventory_qty == 0
+
+
+def test_register_selected_returns_error_when_selection_cannot_be_persisted(client, db_session, monkeypatch):
+    user = login_user(client, db_session, 'register_selected_rejected_user')
+    fake_queue = FakeQueue()
+    fake_queue.jobs['job-1'] = {
+        'job_id': 'job-1',
+        'status': 'completed',
+        'result': {
+            'items': [
+                {
+                    'url': 'https://example.com/blocked-item',
+                    'title': 'Blocked Item',
+                    'price': None,
+                    'status': 'blocked',
+                    'description': '',
+                    'image_urls': [],
+                },
+            ],
+            'site': 'mercari',
+        },
+        'error': None,
+        'elapsed_seconds': 0.1,
+        'queue_position': None,
+        'user_id': user.id,
+    }
+
+    monkeypatch.setattr('routes.scrape.get_queue', lambda: fake_queue)
+
+    response = client.post('/scrape/register-selected', json={
+        'job_id': 'job-1',
+        'selected_indices': [0]
+    })
+
+    assert response.status_code == 422
+    assert response.json['registered_count'] == 0
+    assert response.json['rejected_count'] == 1
+    assert db_session.query(Product).filter_by(user_id=user.id).count() == 0
 
 
 def test_register_selected_requires_csrf_header_when_enabled(app, client, db_session, monkeypatch):


### PR DESCRIPTION
## Summary
- Normalize scraped prices, image URLs, variants, and inventory values before product persistence.
- Make manual preview registration report the actual persisted count and return an error when selected items cannot be saved.
- Keep duplicate source URLs isolated by shop so registration for one shop does not update another shop's product.

## Root Cause
Some scraper outputs, especially from sites with richer item and variant payloads such as Yahoo Shopping, can return price or inventory values in non-integer shapes or omit price/status confidence. The selected-registration endpoint also reported the selected count rather than the successfully persisted count, which could make a rejected save look successful while the product never appeared in the list.

## Impact
Users can explicitly register selected preview items even when price is missing, and rejected items now surface as a registration error instead of a false success. Existing automatic persistence remains conservative for uncertain scrape results.

## Validation
- `pytest tests/test_scrape_preview_flow.py tests/test_product_service.py -q`
- `pytest tests/test_e2e_routes.py -q`
- `pytest tests/test_pre_arc_checklist.py tests/test_queue_backend.py -q`
- `pytest tests/test_rq_scrape_e2e.py tests/test_scrape_job_store.py tests/test_scrape_job_runtime.py -q`