### PR TITLE
[codex] Fix Surugaya scraping extraction

### DIFF
--- a/config/element_fingerprints.json
+++ b/config/element_fingerprints.json
@@ -248,7 +248,15 @@
             },
             "description": {
                 "validators": {
-                    "min_length": 10
+                    "min_length": 10,
+                    "must_not_contain": [
+                        "全商品",
+                        "セーフサーチ",
+                        "サインインはこちら",
+                        "カートはこちら",
+                        "ショッピングを続ける",
+                        "注文手続きを行う"
+                    ]
                 },
                 "fingerprint": {
                     "tag_names": ["div", "table", "section"],

--- a/config/scraping_selectors.json
+++ b/config/scraping_selectors.json
@@ -206,7 +206,12 @@
                 "[itemprop='price']"
             ],
             "description": [
-                "html > body > div:nth-of-type(1)"
+                ".note.text-break",
+                "#item_detailInfo",
+                ".tbl_product_info",
+                "#item_condition",
+                "#product_detail",
+                "[itemprop='description']"
             ],
             "images": [
                 "html > body > div > div:nth-of-type(1) > div:nth-of-type(4) > div:nth-of-type(1) > div > div:nth-of-type(1) > a > img"

--- a/surugaya_db.py
+++ b/surugaya_db.py
@@ -76,6 +76,8 @@ SELECTORS = {
         "img[data-src*='cdn.suruga-ya.jp/pics_webp/']",
     ],
     "description": [
+        ".note.text-break",
+        "#item_detailInfo",
         ".tbl_product_info",
         "#item_condition",
         "#product_detail",
@@ -233,6 +235,22 @@ def _is_usable_price_value(value) -> bool:
     return isinstance(value, int) and value > 0
 
 
+def _normalize_surugaya_title(text: str) -> str:
+    title = str(text or "").strip()
+    if not title:
+        return ""
+
+    had_site_prefix = False
+    if title.startswith("駿河屋 -"):
+        title = title[len("駿河屋 -"):].strip()
+        had_site_prefix = True
+
+    title = re.sub(r"^<[^>]+>", "", title).strip()
+    if had_site_prefix:
+        title = re.sub(r"（[^（）]{1,40}）$", "", title).strip()
+    return title
+
+
 def _pick_strategy(field_sources: dict) -> str:
     for source in ("payload", "json_ld", "meta", "css", "derived"):
         if source in field_sources.values():
@@ -344,6 +362,52 @@ def _is_placeholder_image(url: str) -> bool:
         or "bglogo" in lowered
         or "logo-surugaya" in lowered
     )
+
+
+_DESCRIPTION_NOISE_MARKERS = (
+    "全商品",
+    "セーフサーチ",
+    "サインインはこちら",
+    "カートはこちら",
+    "キャンペーン",
+    "駿河屋TOP",
+    "数量の選択",
+    "ショッピングを続ける",
+    "注文手続きを行う",
+)
+
+
+def _is_plausible_description(text: str) -> bool:
+    cleaned = str(text or "").strip()
+    if len(cleaned) < 10:
+        return False
+    return not any(marker in cleaned for marker in _DESCRIPTION_NOISE_MARKERS)
+
+
+def _extract_meta_description(soup: BeautifulSoup) -> tuple[str, str]:
+    meta_candidates = (
+        ("meta", "meta[name='description']"),
+        ("meta", "meta[property='og:description']"),
+    )
+    for source, selector in meta_candidates:
+        meta_el = soup.select_one(selector)
+        if not meta_el:
+            continue
+        text = (meta_el.get("content") or "").strip()
+        if _is_plausible_description(text):
+            return text, source
+    return "", ""
+
+
+def _extract_css_description(soup: BeautifulSoup) -> str:
+    for selector in SELECTORS["description"]:
+        detail_el = soup.select_one(selector)
+        if not detail_el:
+            continue
+        text = detail_el.get_text(separator="\n", strip=True)
+        if _is_plausible_description(text):
+            return text
+    return ""
 
 
 def _extract_image_urls(soup: BeautifulSoup, page_url: str, ld_product: dict) -> list:
@@ -874,18 +938,18 @@ def scrape_item_detail(session, url: str, headless: bool = True) -> dict:
     if _healer:
         title_val, _ = _healer.extract_with_healing(soup, 'surugaya', 'detail', 'title', parser='bs4')
         if title_val:
-            css_title = title_val
+            css_title = _normalize_surugaya_title(title_val)
     if not css_title:
         for selector in SELECTORS["title"]:
             title_el = soup.select_one(selector)
             if title_el:
                 text = title_el.get_text(" ", strip=True)
                 if text:
-                    css_title = text
+                    css_title = _normalize_surugaya_title(text)
                     break
     og_title = soup.select_one("meta[property='og:title']")
-    og_title_text = og_title.get("content").strip() if og_title and og_title.get("content") else ""
-    ld_title = str(ld_product.get("name") or "").strip()
+    og_title_text = _normalize_surugaya_title(og_title.get("content")) if og_title and og_title.get("content") else ""
+    ld_title = _normalize_surugaya_title(ld_product.get("name"))
     result["title"], title_source = pick_first_valid(
         ("json_ld", ld_title),
         ("meta", og_title_text),
@@ -1001,25 +1065,16 @@ def scrape_item_detail(session, url: str, headless: bool = True) -> dict:
     css_description = ""
     if _healer:
         desc_val, _ = _healer.extract_with_healing(soup, 'surugaya', 'detail', 'description', parser='bs4')
-        if desc_val:
+        if desc_val and _is_plausible_description(desc_val):
             css_description = desc_val
     if not css_description:
-        for selector in SELECTORS["description"]:
-            detail_el = soup.select_one(selector)
-            if not detail_el:
-                continue
-            text = detail_el.get_text(separator="\n", strip=True)
-            if text:
-                css_description = text
-                break
-    meta_description = ""
-    meta_desc_el = soup.select_one("meta[name='description']")
-    if meta_desc_el and meta_desc_el.get("content"):
-        meta_description = meta_desc_el.get("content").strip()
+        css_description = _extract_css_description(soup)
+
+    meta_description, meta_description_source = _extract_meta_description(soup)
     result["description"], description_source = pick_first_valid(
-        ("meta", meta_description),
+        (meta_description_source, meta_description),
         ("css", css_description),
-        validator=_is_usable_text,
+        validator=_is_plausible_description,
         default="",
     )
     if description_source:

--- a/tests/test_extraction_priority.py
+++ b/tests/test_extraction_priority.py
@@ -262,6 +262,94 @@ def test_surugaya_detail_tracks_mixed_provenance_and_invalid_primary_fallback_wi
     assert result["_scrape_meta"]["field_sources"]["images"] == "meta"
 
 
+def test_surugaya_detail_rejects_page_chrome_description_from_healer(monkeypatch):
+    html = """
+    <html>
+      <head>
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "name": "Surugaya Clean Description Item",
+            "image": ["https://cdn.suruga-ya.jp/database/pics_webp/game/clean.jpg.webp"],
+            "offers": {
+              "@type": "Offer",
+              "price": "2980",
+              "availability": "https://schema.org/InStock"
+            }
+          }
+        </script>
+      </head>
+      <body>
+        <div class="dialog-off-canvas-main-canvas">
+          全商品 セーフサーチ サインインはこちら カートはこちら キャンペーン
+        </div>
+        <h1>Surugaya CSS Title</h1>
+        <div class="price_group"><span class="text-price-detail">2,980円(税込)</span></div>
+        <div class="btn_buy">カートに入れる</div>
+        <p class="note text-break">Clean product-only description from the detail note.</p>
+      </body>
+    </html>
+    """
+
+    class FakeHealer:
+        def extract_with_healing(self, page, site, page_type, field, parser="scrapling"):
+            if field == "description":
+                return "全商品 セーフサーチ サインインはこちら カートはこちら キャンペーン", False
+            return "", False
+
+        def extract_images_with_healing(self, page, site, page_type, parser="scrapling"):
+            return [], False
+
+    monkeypatch.setattr(surugaya_db, "_get_healer", lambda: FakeHealer())
+    monkeypatch.setattr(
+        surugaya_db,
+        "_fetch_with_retry",
+        lambda session, url, timeout=30, max_attempts=3: (MockResponse(html, url), None),
+    )
+
+    result = surugaya_db.scrape_item_detail(object(), "https://www.suruga-ya.jp/product/detail/1")
+
+    assert result["description"] == "Clean product-only description from the detail note."
+    assert "全商品" not in result["description"]
+    assert result["_scrape_meta"]["field_sources"]["description"] == "css"
+
+
+def test_surugaya_detail_normalizes_wrapped_meta_title(monkeypatch):
+    html = """
+    <html>
+      <head>
+        <meta property="og:title" content="駿河屋 -&lt;中古&gt;Clean Store Item（その他）" />
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "image": ["https://cdn.suruga-ya.jp/database/pics_webp/goods/store.jpg.webp"],
+            "offers": {
+              "@type": "Offer",
+              "price": "1200",
+              "availability": "https://schema.org/InStock"
+            }
+          }
+        </script>
+      </head>
+      <body>
+        <h1>食器 Clean Store Item</h1>
+        <div class="price_group"><span class="text-price-detail">1,200円(税込)</span></div>
+        <div class="btn_buy">カートに入れる</div>
+        <p class="note text-break">Clean store item description.</p>
+      </body>
+    </html>
+    """
+
+    monkeypatch.setattr(surugaya_db, "_fetch_with_retry", lambda session, url, timeout=30, max_attempts=3: (MockResponse(html, url), None))
+
+    result = surugaya_db.scrape_item_detail(object(), "https://www.suruga-ya.jp/product/detail/1?tenpo_cd=1")
+
+    assert result["title"] == "Clean Store Item"
+    assert result["_scrape_meta"]["field_sources"]["title"] == "meta"
+
+
 def test_surugaya_detail_marks_javascript_disabled_page_unknown_and_alerts(monkeypatch):
     html = """
     <html>


### PR DESCRIPTION
## Summary
- Fix Surugaya detail descriptions so broad page chrome is rejected and product-only descriptions are preferred.
- Normalize Surugaya titles from wrapped `og:title` values, removing the site prefix, condition tag, and trailing category wrapper.
- Update Surugaya selector and healer configuration to avoid rediscovering the whole page as a description.
- Add regression tests for noisy description extraction and wrapped meta titles.

## Root Cause
Surugaya's healed description selector had drifted to `html > body > div:nth-of-type(1)`, which captured navigation, sign-in, cart, and modal text along with product details. Store inventory detail URLs can also omit useful JSON-LD names, causing the scraper to use raw `og:title` values such as `駿河屋 -<中古>...（その他）` as product names.

## Validation
- `pytest tests/test_extraction_priority.py tests/test_search_result_count_guarantees.py tests/test_stage4_selenium_removal.py tests/test_inventory_status_fail_closed.py -q`
- Live smoke: direct Surugaya item description shrank from page-wide text to product-only text.
- Live smoke: Surugaya search sample returned titles, prices, images, and product-only descriptions for the first three items.
- Live smoke: store inventory URL title normalized to the product name only.