### PR TITLE
[codex] Fix patrol scheduling timestamps

### DIFF
--- a/alembic/versions/20260424_0008_add_product_patrol_schedule_columns.py
+++ b/alembic/versions/20260424_0008_add_product_patrol_schedule_columns.py
@@ -1,0 +1,84 @@
+"""add product patrol schedule columns
+
+Revision ID: 20260424_0008
+Revises: 20260422_0006
+Create Date: 2026-04-24 00:08:00
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260424_0008"
+down_revision = "20260422_0006"
+branch_labels = None
+depends_on = None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if "products" not in existing_tables:
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns("products")}
+    existing_indexes = {index["name"] for index in inspector.get_indexes("products")}
+
+    with op.batch_alter_table("products") as batch_op:
+        if "last_patrolled_at" not in existing_columns:
+            batch_op.add_column(sa.Column("last_patrolled_at", sa.DateTime(), nullable=True))
+        if "next_patrol_at" not in existing_columns:
+            batch_op.add_column(sa.Column("next_patrol_at", sa.DateTime(), nullable=True))
+        if "ix_products_last_patrolled_at" not in existing_indexes:
+            batch_op.create_index("ix_products_last_patrolled_at", ["last_patrolled_at"], unique=False)
+        if "ix_products_next_patrol_at" not in existing_indexes:
+            batch_op.create_index("ix_products_next_patrol_at", ["next_patrol_at"], unique=False)
+
+    if {"patrol_fail_count", "updated_at"}.issubset(existing_columns):
+        # Earlier patrol backoff used products.updated_at as the retry cursor.
+        # Preserve that retry time while removing future timestamps from the
+        # product-list sort key.
+        now = _utc_now()
+        bind.execute(
+            sa.text(
+                """
+                UPDATE products
+                SET next_patrol_at = updated_at,
+                    last_patrolled_at = :now,
+                    updated_at = :now
+                WHERE patrol_fail_count > 0
+                  AND updated_at > :now
+                  AND next_patrol_at IS NULL
+                """
+            ),
+            {"now": now},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    if "products" not in existing_tables:
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns("products")}
+    existing_indexes = {index["name"] for index in inspector.get_indexes("products")}
+
+    with op.batch_alter_table("products") as batch_op:
+        if "ix_products_next_patrol_at" in existing_indexes:
+            batch_op.drop_index("ix_products_next_patrol_at")
+        if "ix_products_last_patrolled_at" in existing_indexes:
+            batch_op.drop_index("ix_products_last_patrolled_at")
+        if "next_patrol_at" in existing_columns:
+            batch_op.drop_column("next_patrol_at")
+        if "last_patrolled_at" in existing_columns:
+            batch_op.drop_column("last_patrolled_at")

--- a/database.py
+++ b/database.py
@@ -73,6 +73,8 @@ ADDITIVE_STARTUP_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
     ("shops", "logo_url", "ALTER TABLE shops ADD COLUMN logo_url VARCHAR"),
     ("description_templates", "user_id", "ALTER TABLE description_templates ADD COLUMN user_id INTEGER"),
     ("products", "patrol_fail_count", "ALTER TABLE products ADD COLUMN patrol_fail_count INTEGER DEFAULT 0"),
+    ("products", "last_patrolled_at", "ALTER TABLE products ADD COLUMN last_patrolled_at TIMESTAMP"),
+    ("products", "next_patrol_at", "ALTER TABLE products ADD COLUMN next_patrol_at TIMESTAMP"),
     ("products", "manual_margin_rate", "ALTER TABLE products ADD COLUMN manual_margin_rate INTEGER"),
     ("products", "manual_shipping_cost", "ALTER TABLE products ADD COLUMN manual_shipping_cost INTEGER"),
     ("scrape_jobs", "logical_job_id", "ALTER TABLE scrape_jobs ADD COLUMN logical_job_id VARCHAR(64)"),

--- a/models.py
+++ b/models.py
@@ -87,6 +87,8 @@ class Product(Base):
 
     # Patrol failure tracking (exponential backoff)
     patrol_fail_count = Column(Integer, default=0)
+    last_patrolled_at = Column(DateTime, nullable=True, index=True)
+    next_patrol_at = Column(DateTime, nullable=True, index=True)
 
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now)

--- a/services/monitor_service.py
+++ b/services/monitor_service.py
@@ -5,7 +5,7 @@ Non-Mercari sites use HTTP-only fetching (Scrapling) to avoid launching Chrome.
 """
 import logging
 from datetime import timedelta
-from sqlalchemy import asc
+from sqlalchemy import asc, func, or_
 from database import SessionLocal
 from models import Product, Variant
 from services.pricing_service import product_has_pricing_config, update_product_selling_price
@@ -63,11 +63,13 @@ class MonitorService:
     _MERCARI_SOFT_SOLD_THRESHOLD = 2
     
     @staticmethod
-    def _apply_backoff(product, session_db):
-        """Increment fail count and push updated_at into the future."""
+    def _apply_backoff(product, session_db, now=None):
+        """Increment fail count and schedule the next patrol attempt."""
+        now = now or utc_now()
         product.patrol_fail_count = (product.patrol_fail_count or 0) + 1
         backoff_minutes = min(product.patrol_fail_count * 15, _MAX_BACKOFF_MINUTES)
-        product.updated_at = utc_now() + timedelta(minutes=backoff_minutes)
+        product.last_patrolled_at = now
+        product.next_patrol_at = now + timedelta(minutes=backoff_minutes)
         session_db.commit()
 
     @staticmethod
@@ -93,13 +95,16 @@ class MonitorService:
         }
         
         try:
-            # Find products sorted by updated_at ascending (oldest first)
-            # Exclude archived products - include all supported sites
+            # Find due products by patrol cursor, independent from the
+            # product-list updated_at sort.
+            now = utc_now()
+            patrol_cursor = func.coalesce(Product.last_patrolled_at, Product.updated_at, Product.created_at)
             products = session_db.query(Product).filter(
                 Product.site.in_(list(MonitorService._patrols.keys())),
                 Product.archived != True,
                 Product.deleted_at == None,
-            ).order_by(asc(Product.updated_at)).limit(limit).all()
+                or_(Product.next_patrol_at == None, Product.next_patrol_at <= now),
+            ).order_by(asc(patrol_cursor), asc(Product.id)).limit(limit).all()
 
             summary["selected_count"] = len(products)
             summary["site_counts"] = {
@@ -159,6 +164,8 @@ class MonitorService:
                     
                     # ---- Success: reset fail counter ----
                     product.patrol_fail_count = 0
+                    product.last_patrolled_at = utc_now()
+                    product.next_patrol_at = None
 
                     # ── Mercari sold-hysteresis ──────────────────────────
                     # Soft-evidence "sold" from Mercari is not persisted
@@ -182,7 +189,7 @@ class MonitorService:
                                 result.reason or "",
                             )
                             # Treat as unknown for this cycle — do not persist
-                            product.updated_at = utc_now()
+                            product.updated_at = product.last_patrolled_at
                             session_db.commit()
                             continue
                         else:
@@ -210,7 +217,7 @@ class MonitorService:
                             update_product_selling_price(product.id, session=session_db)
                     
                     # Always update timestamp even if no changes
-                    product.updated_at = utc_now()
+                    product.updated_at = product.last_patrolled_at or utc_now()
                     session_db.commit()
                     
                 except Exception as e:

--- a/tests/test_database_bootstrap.py
+++ b/tests/test_database_bootstrap.py
@@ -1,11 +1,19 @@
 from pathlib import Path
 import uuid
+from datetime import datetime, timedelta
 
 import pytest
 from sqlalchemy import inspect, text
 
 import database
 from models import ScrapeJob, ScrapeJobEvent
+from time_utils import utc_now
+
+
+def _coerce_datetime(value):
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    return value
 
 
 def test_bootstrap_schema_auto_falls_back_to_legacy(monkeypatch):
@@ -193,6 +201,41 @@ def test_apply_additive_startup_migrations_adds_description_template_user_id():
     assert "user_id" in columns
 
 
+def test_apply_additive_startup_migrations_adds_product_patrol_schedule_columns():
+    smoke_db = Path(f"test_db_additive_product_patrol_{uuid.uuid4().hex}.sqlite")
+    smoke_engine = database.create_app_engine(f"sqlite:///{smoke_db.as_posix()}")
+
+    try:
+        with smoke_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE products (
+                        id INTEGER PRIMARY KEY,
+                        user_id INTEGER NOT NULL,
+                        site VARCHAR NOT NULL,
+                        source_url VARCHAR NOT NULL,
+                        patrol_fail_count INTEGER DEFAULT 0,
+                        created_at TIMESTAMP,
+                        updated_at TIMESTAMP
+                    )
+                    """
+                )
+            )
+
+        with smoke_engine.begin() as connection:
+            results = database.apply_additive_startup_migrations(bind=connection)
+        columns = {column["name"] for column in inspect(smoke_engine).get_columns("products")}
+    finally:
+        smoke_engine.dispose()
+        smoke_db.unlink(missing_ok=True)
+
+    assert "products.last_patrolled_at" in results["applied"]
+    assert "products.next_patrol_at" in results["applied"]
+    assert "last_patrolled_at" in columns
+    assert "next_patrol_at" in columns
+
+
 def test_apply_additive_startup_migrations_avoids_missing_column_probe_queries(monkeypatch):
     class FakeInspector:
         def __init__(self, table_columns):
@@ -310,7 +353,94 @@ def test_run_alembic_upgrade_for_database_url_backfills_tracker_dismissed_at_fro
     assert "ix_scrape_jobs_tracker_dismissed_at" in indexes
     assert "selector_repair_candidates" in table_names
     assert "selector_active_rule_sets" in table_names
-    assert version_num == "20260422_0006"
+    assert version_num == "20260424_0008"
+
+
+def test_run_alembic_upgrade_adds_product_patrol_schedule_columns_from_previous_head():
+    smoke_db = Path(f"test_db_alembic_patrol_schedule_{uuid.uuid4().hex}.sqlite")
+    smoke_db_url = f"sqlite:///{smoke_db.resolve().as_posix()}"
+    smoke_engine = database.create_app_engine(smoke_db_url)
+
+    try:
+        with smoke_engine.begin() as connection:
+            connection.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+            connection.execute(text("INSERT INTO alembic_version (version_num) VALUES ('20260422_0006')"))
+            connection.execute(
+                text(
+                    """
+                    CREATE TABLE products (
+                        id INTEGER PRIMARY KEY,
+                        user_id INTEGER NOT NULL,
+                        site VARCHAR NOT NULL,
+                        source_url VARCHAR NOT NULL,
+                        patrol_fail_count INTEGER DEFAULT 0,
+                        created_at TIMESTAMP,
+                        updated_at TIMESTAMP
+                    )
+                    """
+                )
+            )
+            legacy_backoff_until = utc_now() + timedelta(hours=1)
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO products (
+                        id,
+                        user_id,
+                        site,
+                        source_url,
+                        patrol_fail_count,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        1,
+                        1,
+                        'mercari',
+                        'https://jp.mercari.com/item/m123',
+                        2,
+                        :created_at,
+                        :updated_at
+                    )
+                    """
+                ),
+                {
+                    "created_at": utc_now() - timedelta(days=2),
+                    "updated_at": legacy_backoff_until,
+                },
+            )
+
+        database.run_alembic_upgrade_for_database_url(smoke_db_url)
+
+        upgraded_engine = database.create_app_engine(smoke_db_url)
+        try:
+            inspector = inspect(upgraded_engine)
+            product_columns = {column["name"] for column in inspector.get_columns("products")}
+            product_indexes = {index["name"] for index in inspector.get_indexes("products")}
+            with upgraded_engine.connect() as connection:
+                version_num = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+                migrated_product = connection.execute(
+                    text(
+                        """
+                        SELECT updated_at, last_patrolled_at, next_patrol_at
+                        FROM products
+                        WHERE id = 1
+                        """
+                    )
+                ).mappings().one()
+        finally:
+            upgraded_engine.dispose()
+    finally:
+        smoke_engine.dispose()
+        smoke_db.unlink(missing_ok=True)
+
+    assert "last_patrolled_at" in product_columns
+    assert "next_patrol_at" in product_columns
+    assert "ix_products_last_patrolled_at" in product_indexes
+    assert "ix_products_next_patrol_at" in product_indexes
+    assert version_num == "20260424_0008"
+    assert _coerce_datetime(migrated_product["next_patrol_at"]) == legacy_backoff_until
+    assert _coerce_datetime(migrated_product["updated_at"]) <= utc_now()
+    assert _coerce_datetime(migrated_product["last_patrolled_at"]) <= utc_now()
 
 
 def test_inspect_additive_schema_drift_reports_missing_scrape_job_columns():

--- a/tests/test_monitor_service.py
+++ b/tests/test_monitor_service.py
@@ -87,7 +87,7 @@ def test_monitor_service_skips_deleted_products(client, db_session, monkeypatch)
 
 
 def test_invalid_url_skipped_with_backoff(client, db_session, monkeypatch):
-    """Products with search URLs are skipped and get backoff applied."""
+    """Products with search URLs are skipped and get patrol backoff applied."""
     user = _create_user(db_session, 'monitor_invalid_url_user')
     old_time = utc_now() - timedelta(days=1)
 
@@ -120,14 +120,17 @@ def test_invalid_url_skipped_with_backoff(client, db_session, monkeypatch):
     assert fake_patrol.called_urls == []
     # Fail count incremented
     assert refreshed.patrol_fail_count == 1
-    # updated_at pushed into the future (at least 10 min from now)
-    assert refreshed.updated_at > utc_now() + timedelta(minutes=10)
+    # Product-list updated_at is not used as a patrol backoff cursor.
+    assert refreshed.updated_at == old_time
+    assert refreshed.last_patrolled_at is not None
+    # next_patrol_at is pushed into the future (at least 10 min from now)
+    assert refreshed.next_patrol_at > utc_now() + timedelta(minutes=10)
     # Price unchanged
     assert refreshed.last_price == 500
 
 
-def test_patrol_failure_updates_timestamp(client, db_session, monkeypatch):
-    """When patrol.fetch returns an error, backoff is applied."""
+def test_patrol_failure_records_patrol_backoff_without_touching_list_timestamp(client, db_session, monkeypatch):
+    """When patrol.fetch returns an error, backoff is applied outside updated_at."""
     user = _create_user(db_session, 'monitor_fail_ts_user')
     old_time = utc_now() - timedelta(days=1)
 
@@ -157,8 +160,11 @@ def test_patrol_failure_updates_timestamp(client, db_session, monkeypatch):
 
     # Fail count incremented from 2 → 3
     assert refreshed.patrol_fail_count == 3
-    # updated_at pushed into the future (3 * 15 = 45 min backoff)
-    assert refreshed.updated_at > utc_now() + timedelta(minutes=40)
+    # updated_at remains the product-list update timestamp
+    assert refreshed.updated_at == old_time
+    assert refreshed.last_patrolled_at is not None
+    # next_patrol_at carries the 3 * 15 = 45 min backoff
+    assert refreshed.next_patrol_at > utc_now() + timedelta(minutes=40)
     # Price NOT changed
     assert refreshed.last_price == 2000
 
@@ -194,11 +200,66 @@ def test_patrol_success_resets_fail_count(client, db_session, monkeypatch):
 
     # Fail count reset
     assert refreshed.patrol_fail_count == 0
+    assert refreshed.next_patrol_at is None
+    assert refreshed.last_patrolled_at is not None
     # Price updated
     assert refreshed.last_price == 3500
     assert refreshed.last_status == 'on_sale'
     # updated_at should be recent (not in the future)
     assert refreshed.updated_at <= utc_now() + timedelta(seconds=10)
+
+def test_backoff_product_is_skipped_until_next_patrol_at(client, db_session, monkeypatch):
+    user = _create_user(db_session, 'monitor_backoff_skip_user')
+    old_time = utc_now() - timedelta(days=2)
+    recent_time = utc_now() - timedelta(minutes=1)
+
+    backed_off = Product(
+        user_id=user.id,
+        site='mercari',
+        source_url='https://jp.mercari.com/item/m-backed-off',
+        last_title='Backed Off Item',
+        last_price=1000,
+        last_status='on_sale',
+        archived=False,
+        deleted_at=None,
+        patrol_fail_count=1,
+        created_at=old_time,
+        updated_at=old_time,
+        last_patrolled_at=recent_time,
+        next_patrol_at=utc_now() + timedelta(minutes=30),
+    )
+    due_product = Product(
+        user_id=user.id,
+        site='mercari',
+        source_url='https://jp.mercari.com/item/m-due-now',
+        last_title='Due Item',
+        last_price=2000,
+        last_status='on_sale',
+        archived=False,
+        deleted_at=None,
+        patrol_fail_count=0,
+        created_at=old_time,
+        updated_at=old_time + timedelta(minutes=1),
+        last_patrolled_at=None,
+        next_patrol_at=None,
+    )
+    db_session.add_all([backed_off, due_product])
+    db_session.commit()
+
+    ok_patrol = FakePatrol(PatrolResult(price=2500, status='active', variants=[]))
+    monkeypatch.setattr(MonitorService, '_patrols', {'mercari': ok_patrol})
+
+    MonitorService.check_stale_products(limit=10)
+
+    db_session.expire_all()
+    refreshed_backed_off = db_session.query(Product).filter_by(id=backed_off.id).one()
+    refreshed_due = db_session.query(Product).filter_by(id=due_product.id).one()
+
+    assert ok_patrol.called_urls == ['https://jp.mercari.com/item/m-due-now']
+    assert refreshed_backed_off.last_price == 1000
+    assert refreshed_backed_off.next_patrol_at is not None
+    assert refreshed_due.last_price == 2500
+    assert refreshed_due.next_patrol_at is None
 
 
 def test_patrol_deleted_status_only_preserves_price_and_zeroes_inventory(client, db_session, monkeypatch):


### PR DESCRIPTION
## Summary

- separate patrol retry scheduling from the product-list `updated_at` timestamp
- add `last_patrolled_at` and `next_patrol_at` product columns with Alembic/additive bootstrap support
- migrate legacy future `updated_at` retry timestamps into `next_patrol_at` so update-order sorting is not polluted
- keep successful patrols updating `updated_at` so patrol-checked products appear in update-order sorting

## Root Cause

Patrol backoff reused `products.updated_at` as a retry cursor. That same field drives the product list's update-order sort, so failed patrol attempts could push products into future timestamps and mix retry scheduling with visible catalog ordering.

## Validation

- `py -m pytest tests/test_monitor_service.py tests/test_database_bootstrap.py tests/test_worker_runtime.py tests/test_worker_entrypoint.py -q`
- `py -m pytest tests/test_e2e_routes.py tests/test_scrape_tasks.py tests/test_search_result_count_guarantees.py tests/test_inventory_status_fail_closed.py tests/test_mercari_patrol_playwright.py tests/test_rakuma_playwright.py tests/test_snkrdunk_detail_parser.py tests/test_stage4_selenium_removal.py tests/test_scraping_client_async.py tests/test_scrape_queue.py tests/test_scrape_job_runtime.py tests/test_mercari_sold_hysteresis.py -q`
- `py -m pytest tests/test_cli_render_cutover_readiness.py tests/test_cli_render_worker_postdeploy_checklist.py -q`
- `py -m flask --app app:app render-worker-postdeploy-checklist --blueprint-path render.yaml`
- `py -m alembic heads`